### PR TITLE
Remove Sync + Send requirement on wrapped Reader

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -135,7 +135,7 @@ impl<R: Read + Unpin> ArchiveBuilder<R> {
     }
 }
 
-impl<R: Read + Unpin + Sync + Send> Archive<R> {
+impl<R: Read + Unpin> Archive<R> {
     /// Create a new archive with the underlying object as the reader.
     pub fn new(obj: R) -> Archive<R> {
         Archive {


### PR DESCRIPTION
Hi, I think the Sync+Send requirement on the reader wrapped by `Archive` is not neccessary. I stumbled across this in a project of mine where I tried to use a type which was `Send` only. If I missed something and there is a reason for the restriction, please disregard this PR :)