### PR TITLE
drop unnecessary sync marker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install Rust (macos)
       run: |
         curl https://sh.rustup.rs | sh -s -- -y
-        echo "##[add-path]$HOME/.cargo/bin"
+        echo "$HOME/.cargo/bin" >>$GITHUB_PATH
       if: matrix.os == 'macos-latest'
     - run: cargo test
     - run: cargo test --no-default-features

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -116,7 +116,7 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append<R: Read + Unpin + Sync + Send>(
+    pub async fn append<R: Read + Unpin + Send>(
         &mut self,
         header: &Header,
         mut data: R,
@@ -170,7 +170,7 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append_data<P: AsRef<Path>, R: Read + Unpin + Sync + Send>(
+    pub async fn append_data<P: AsRef<Path>, R: Read + Unpin + Send>(
         &mut self,
         header: &mut Header,
         path: P,
@@ -406,9 +406,9 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
 }
 
 async fn append(
-    mut dst: &mut (dyn Write + Unpin + Send + Sync),
+    mut dst: &mut (dyn Write + Unpin + Send),
     header: &Header,
-    mut data: &mut (dyn Read + Unpin + Send + Sync),
+    mut data: &mut (dyn Read + Unpin + Send),
 ) -> io::Result<()> {
     dst.write_all(header.as_bytes()).await?;
     let len = io::copy(&mut data, &mut dst).await?;

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -633,7 +633,7 @@ impl<R: Read + Unpin> EntryFields<R> {
                 .create_new(true)
                 .open(dst)
                 .await
-        };
+        }
         let mut f = async {
             let mut f = match open(dst).await {
                 Ok(f) => Ok(f),


### PR DESCRIPTION
Precipitated by this change: https://github.com/rusoto/rusoto/issues/1896 which eventually propagates to our package here: https://github.com/swift-nav/esthri/blob/master/src/esthri/src/http_server.rs#L346 and causes a compile error because `.append_data` requires the stream to be Send+Sync.  Dropping the Sync marker seems to work here, assuming that it isn't actually needed for some other reason?

And FWIW, this was encountered while updating Rusoto here: https://github.com/swift-nav/esthri/pull/184/files -- our package combines types from rusoto and async-tar.