### PR TITLE
fix: preserve intermediate entry state 

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -122,6 +122,7 @@ pub struct GnuSparseHeader {
 /// the next entry will be one of these headers.
 #[repr(C)]
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct GnuExtSparseHeader {
     pub sparse: [GnuSparseHeader; 21],
     pub isextended: [u8; 1],


### PR DESCRIPTION
This fixes a bug in which extension entries will be dropped if the
read of the entry's data returns `Pending`.