### PR TITLE
Fix windows compile error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ contents are never required to be entirely resident in memory all at once.
 """
 
 [dependencies]
-async-std = "1.6.0"
+async-std = {version = "1.6.0", features = ["unstable"] }
 filetime = "0.2.8"
 pin-project = "1.0.8"
 


### PR DESCRIPTION
in entry.rs:588:
```rust
async_std::os::windows::fs::symlink_file(src, dst).await
// (Could not find `fs` in `windows`)
```