### PR TITLE
Add the unstable feature to async-std to fix compilation on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ contents are never required to be entirely resident in memory all at once.
 """
 
 [dependencies]
-async-std = "1.6.0"
+async-std = { version = "1.6.0", features = ["unstable"] }
 filetime = "0.2.8"
 pin-project = "1.0.8"
 


### PR DESCRIPTION
This PR adds the `unstable` feature to `async-std` to fix the broken build on windows.

Closes #48 
Closes #35 