### PR TITLE
WIP: Move from async-std to the recommended smol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,11 @@ contents are never required to be entirely resident in memory all at once.
 """
 
 [dependencies]
-async-std = { version = "1.12.0", features = ["unstable"] }
 filetime = "0.2.8"
 pin-project = "1.0.8"
+smol = "2.0.2"
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = ["unstable", "attributes"] }
 static_assertions = "1.1.0"
 tempfile = "3"
 

--- a/examples/extract_file.rs
+++ b/examples/extract_file.rs
@@ -6,25 +6,28 @@
 
 extern crate async_tar;
 
-use async_std::{
-    io::{copy, stdin, stdout},
-    path::Path,
-    prelude::*,
-};
+use smol::{io::copy, stream::StreamExt, Unblock};
 use std::env::args_os;
+use std::io::{stdin, stdout};
+use std::path::Path;
 
 use async_tar::Archive;
 
 fn main() {
-    async_std::task::block_on(async {
-        let first_arg = args_os().nth(1).unwrap();
-        let filename = Path::new(&first_arg);
-        let ar = Archive::new(stdin());
-        let mut entries = ar.entries().unwrap();
+    let first_arg = args_os().nth(1).unwrap();
+    let filename = Path::new(&first_arg);
+
+    let input = Unblock::new(stdin());
+    let mut output = Unblock::new(stdout());
+
+    smol::block_on(async {
+        let archives = Archive::new(input);
+        let mut entries = archives.entries().unwrap();
+
         while let Some(file) = entries.next().await {
             let mut f = file.unwrap();
             if f.path().unwrap() == filename {
-                copy(&mut f, &mut stdout()).await.unwrap();
+                copy(&mut f, &mut output).await.unwrap();
             }
         }
     });

--- a/examples/list.rs
+++ b/examples/list.rs
@@ -4,13 +4,16 @@
 
 extern crate async_tar;
 
-use async_std::{io::stdin, prelude::*};
+use smol::stream::StreamExt;
+use smol::Unblock;
+use std::io::stdin;
 
 use async_tar::Archive;
 
 fn main() {
-    async_std::task::block_on(async {
-        let ar = Archive::new(stdin());
+    let stdin = Unblock::new(stdin());
+    smol::block_on(async {
+        let ar = Archive::new(stdin);
         let mut entries = ar.entries().unwrap();
         while let Some(file) = entries.next().await {
             let f = file.unwrap();

--- a/examples/raw_list.rs
+++ b/examples/raw_list.rs
@@ -4,13 +4,15 @@
 
 extern crate async_tar;
 
-use async_std::{io::stdin, prelude::*};
+use smol::stream::StreamExt;
+use smol::Unblock;
+use std::io::stdin;
 
 use async_tar::Archive;
 
 fn main() {
-    async_std::task::block_on(async {
-        let ar = Archive::new(stdin());
+    smol::block_on(async {
+        let ar = Archive::new(Unblock::new(stdin()));
         let mut i = 0;
         let mut entries = ar.entries_raw().unwrap();
         while let Some(file) = entries.next().await {

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -1,10 +1,10 @@
 extern crate async_tar;
 
-use async_std::fs::File;
 use async_tar::Builder;
+use smol::fs::File;
 
 fn main() {
-    async_std::task::block_on(async {
+    smol::block_on(async {
         let file = File::create("foo.tar").await.unwrap();
         let mut a = Builder::new(file);
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -4,33 +4,33 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use async_std::{
-    fs, io,
-    io::prelude::*,
-    path::Path,
-    prelude::*,
-    stream::Stream,
-    task::{Context, Poll},
-};
+use core::task::{Context, Poll};
 use pin_project::pin_project;
+use smol::{
+    fs, io,
+    io::{AsyncRead, AsyncReadExt},
+    stream::{Stream, StreamExt},
+};
+
+use std::path::Path;
 
 use crate::{
-    Entry, GnuExtSparseHeader, GnuSparseHeader, Header,
     entry::{EntryFields, EntryIo},
     error::TarError,
     other,
     pax::pax_extensions,
+    Entry, GnuExtSparseHeader, GnuSparseHeader, Header,
 };
 
 /// A top-level representation of an archive file.
 ///
 /// This archive can have an entry added to it and it can be iterated over.
 #[derive(Debug)]
-pub struct Archive<R: Read + Unpin> {
+pub struct Archive<R: AsyncRead + Unpin> {
     inner: Arc<Mutex<ArchiveInner<R>>>,
 }
 
-impl<R: Read + Unpin> Clone for Archive<R> {
+impl<R: AsyncRead + Unpin> Clone for Archive<R> {
     fn clone(&self) -> Self {
         Archive {
             inner: self.inner.clone(),
@@ -40,7 +40,7 @@ impl<R: Read + Unpin> Clone for Archive<R> {
 
 #[pin_project]
 #[derive(Debug)]
-pub struct ArchiveInner<R: Read + Unpin> {
+pub struct ArchiveInner<R: AsyncRead + Unpin> {
     pos: u64,
     unpack_xattrs: bool,
     preserve_permissions: bool,
@@ -51,7 +51,7 @@ pub struct ArchiveInner<R: Read + Unpin> {
 }
 
 /// Configure the archive.
-pub struct ArchiveBuilder<R: Read + Unpin> {
+pub struct ArchiveBuilder<R: AsyncRead + Unpin> {
     obj: R,
     unpack_xattrs: bool,
     preserve_permissions: bool,
@@ -59,7 +59,7 @@ pub struct ArchiveBuilder<R: Read + Unpin> {
     ignore_zeros: bool,
 }
 
-impl<R: Read + Unpin> ArchiveBuilder<R> {
+impl<R: AsyncRead + Unpin> ArchiveBuilder<R> {
     /// Create a new builder.
     pub fn new(obj: R) -> Self {
         ArchiveBuilder {
@@ -134,7 +134,7 @@ impl<R: Read + Unpin> ArchiveBuilder<R> {
     }
 }
 
-impl<R: Read + Unpin> Archive<R> {
+impl<R: AsyncRead + Unpin> Archive<R> {
     /// Create a new archive with the underlying object as the reader.
     pub fn new(obj: R) -> Archive<R> {
         Archive {
@@ -214,9 +214,9 @@ impl<R: Read + Unpin> Archive<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { smol::block_on(async {
     /// #
-    /// use async_std::fs::File;
+    /// use smol::fs::File;
     /// use async_tar::Archive;
     ///
     /// let mut ar = Archive::new(File::open("foo.tar").await?);
@@ -227,12 +227,12 @@ impl<R: Read + Unpin> Archive<R> {
     pub async fn unpack<P: AsRef<Path>>(self, dst: P) -> io::Result<()> {
         let mut entries = self.entries()?;
         let mut pinned = Pin::new(&mut entries);
-        let dst = dst.as_ref();
+        let dst_path = dst.as_ref().to_path_buf();
 
-        if dst.symlink_metadata().await.is_err() {
-            fs::create_dir_all(&dst)
-                .await
-                .map_err(|e| TarError::new(&format!("failed to create `{}`", dst.display()), e))?;
+        if smol::fs::symlink_metadata(&dst_path).await.is_err() {
+            fs::create_dir_all(dst).await.map_err(|e| {
+                TarError::new(&format!("failed to create `{}`", dst_path.display()), e)
+            })?;
         }
 
         // Canonicalizing the dst directory will prepend the path with '\\?\'
@@ -240,10 +240,7 @@ impl<R: Read + Unpin> Archive<R> {
         // extended-length path with a 32,767 character limit. Otherwise all
         // unpacked paths over 260 characters will fail on creation with a
         // NotFound exception.
-        let dst = &dst
-            .canonicalize()
-            .await
-            .unwrap_or_else(|_| dst.to_path_buf());
+        let dst = smol::fs::canonicalize(&dst_path).await.unwrap_or(dst_path);
 
         // Delay any directory entries until the end (they will be created if needed by
         // descendants), to ensure that directory permissions do not interfer with descendant
@@ -254,11 +251,11 @@ impl<R: Read + Unpin> Archive<R> {
             if file.header().entry_type() == crate::EntryType::Directory {
                 directories.push(file);
             } else {
-                file.unpack_in(dst).await?;
+                file.unpack_in(&dst).await?;
             }
         }
         for mut dir in directories {
-            dir.unpack_in(dst).await?;
+            dir.unpack_in(&dst).await?;
         }
 
         Ok(())
@@ -277,7 +274,7 @@ struct State {
 /// Stream of `Entry`s.
 #[pin_project]
 #[derive(Debug)]
-pub struct Entries<R: Read + Unpin> {
+pub struct Entries<R: AsyncRead + Unpin> {
     archive: Archive<R>,
     current: State,
     fields: Option<EntryFields<Archive<R>>>,
@@ -288,7 +285,7 @@ pub struct Entries<R: Read + Unpin> {
 
 macro_rules! ready_opt_err {
     ($val:expr) => {
-        match async_std::task::ready!($val) {
+        match smol::ready!($val) {
             Some(Ok(val)) => val,
             Some(Err(err)) => return Poll::Ready(Some(Err(err))),
             None => return Poll::Ready(None),
@@ -298,14 +295,14 @@ macro_rules! ready_opt_err {
 
 macro_rules! ready_err {
     ($val:expr) => {
-        match async_std::task::ready!($val) {
+        match smol::ready!($val) {
             Ok(val) => val,
             Err(err) => return Poll::Ready(Some(Err(err))),
         }
     };
 }
 
-impl<R: Read + Unpin> Stream for Entries<R> {
+impl<R: AsyncRead + Unpin> Stream for Entries<R> {
     type Item = io::Result<Entry<Archive<R>>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -398,12 +395,12 @@ impl<R: Read + Unpin> Stream for Entries<R> {
 }
 
 /// Stream of raw `Entry`s.
-pub struct RawEntries<R: Read + Unpin> {
+pub struct RawEntries<R: AsyncRead + Unpin> {
     archive: Archive<R>,
     current: (u64, Option<Header>, usize),
 }
 
-impl<R: Read + Unpin> Stream for RawEntries<R> {
+impl<R: AsyncRead + Unpin> Stream for RawEntries<R> {
     type Item = io::Result<Entry<Archive<R>>>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -413,7 +410,7 @@ impl<R: Read + Unpin> Stream for RawEntries<R> {
     }
 }
 
-fn poll_next_raw<R: Read + Unpin>(
+fn poll_next_raw<R: AsyncRead + Unpin>(
     archive: &Archive<R>,
     next: &mut u64,
     current_header: &mut Option<Header>,
@@ -428,7 +425,7 @@ fn poll_next_raw<R: Read + Unpin>(
         // Seek to the start of the next header in the archive
         if current_header.is_none() {
             let delta = *next - archive.inner.lock().unwrap().pos;
-            match async_std::task::ready!(poll_skip(archive.clone(), cx, delta)) {
+            match smol::ready!(poll_skip(archive.clone(), cx, delta)) {
                 Ok(_) => {}
                 Err(err) => return Poll::Ready(Some(Err(err))),
             }
@@ -440,7 +437,7 @@ fn poll_next_raw<R: Read + Unpin>(
         let header = current_header.as_mut().unwrap();
 
         // EOF is an indicator that we are at the end of the archive.
-        match async_std::task::ready!(poll_try_read_all(
+        match smol::ready!(poll_try_read_all(
             archive.clone(),
             cx,
             header.as_mut_bytes(),
@@ -571,7 +568,7 @@ fn poll_next_raw<R: Read + Unpin>(
     Poll::Ready(Some(Ok(ret.into_entry())))
 }
 
-fn poll_parse_sparse_header<R: Read + Unpin>(
+fn poll_parse_sparse_header<R: AsyncRead + Unpin>(
     archive: &Archive<R>,
     next: &mut u64,
     current_ext: &mut Option<GnuExtSparseHeader>,
@@ -662,7 +659,7 @@ fn poll_parse_sparse_header<R: Read + Unpin>(
 
             let ext = current_ext.as_mut().unwrap();
             while ext.is_extended() {
-                match async_std::task::ready!(poll_try_read_all(
+                match smol::ready!(poll_try_read_all(
                     archive.clone(),
                     cx,
                     ext.as_mut_bytes(),
@@ -697,7 +694,7 @@ fn poll_parse_sparse_header<R: Read + Unpin>(
     Poll::Ready(Ok(()))
 }
 
-impl<R: Read + Unpin> Read for Archive<R> {
+impl<R: AsyncRead + Unpin> AsyncRead for Archive<R> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -707,7 +704,7 @@ impl<R: Read + Unpin> Read for Archive<R> {
         let mut inner = Pin::new(&mut *lock);
         let r = Pin::new(&mut inner.obj);
 
-        let res = async_std::task::ready!(r.poll_read(cx, into));
+        let res = smol::ready!(r.poll_read(cx, into));
         match res {
             Ok(i) => {
                 inner.pos += i as u64;
@@ -722,14 +719,14 @@ impl<R: Read + Unpin> Read for Archive<R> {
 ///
 /// If the reader reaches its end before filling the buffer at all, returns `false`.
 /// Otherwise returns `true`.
-fn poll_try_read_all<R: Read + Unpin>(
+fn poll_try_read_all<R: AsyncRead + Unpin>(
     mut source: R,
     cx: &mut Context<'_>,
     buf: &mut [u8],
     pos: &mut usize,
 ) -> Poll<io::Result<bool>> {
     while *pos < buf.len() {
-        match async_std::task::ready!(Pin::new(&mut source).poll_read(cx, &mut buf[*pos..])) {
+        match smol::ready!(Pin::new(&mut source).poll_read(cx, &mut buf[*pos..])) {
             Ok(0) => {
                 if *pos == 0 {
                     return Poll::Ready(Ok(false));
@@ -747,7 +744,7 @@ fn poll_try_read_all<R: Read + Unpin>(
 }
 
 /// Skip n bytes on the given source.
-fn poll_skip<R: Read + Unpin>(
+fn poll_skip<R: AsyncRead + Unpin>(
     mut source: R,
     cx: &mut Context<'_>,
     mut amt: u64,
@@ -755,7 +752,7 @@ fn poll_skip<R: Read + Unpin>(
     let mut buf = [0u8; 4096 * 8];
     while amt > 0 {
         let n = cmp::min(amt, buf.len() as u64);
-        match async_std::task::ready!(Pin::new(&mut source).poll_read(cx, &mut buf[..n as usize])) {
+        match smol::ready!(Pin::new(&mut source).poll_read(cx, &mut buf[..n as usize])) {
             Ok(0) => {
                 return Poll::Ready(Err(other("unexpected EOF during skip")));
             }
@@ -773,8 +770,8 @@ fn poll_skip<R: Read + Unpin>(
 mod tests {
     use super::*;
 
-    assert_impl_all!(async_std::fs::File: Send, Sync);
-    assert_impl_all!(Entries<async_std::fs::File>: Send, Sync);
-    assert_impl_all!(Archive<async_std::fs::File>: Send, Sync);
-    assert_impl_all!(Entry<Archive<async_std::fs::File>>: Send, Sync);
+    assert_impl_all!(smol::fs::File: Send, Sync);
+    assert_impl_all!(Entries<smol::fs::File>: Send, Sync);
+    assert_impl_all!(Archive<smol::fs::File>: Send, Sync);
+    assert_impl_all!(Entry<Archive<smol::fs::File>>: Send, Sync);
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 
-use async_std::{
+use smol::{
     fs,
-    io::{self, Read, Write},
-    path::Path,
-    prelude::*,
+    io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    stream::StreamExt,
 };
+use std::path::Path;
 
 use crate::{
     header::{bytes2path, path2bytes, HeaderMode},
@@ -16,14 +16,14 @@ use crate::{
 ///
 /// This structure has methods for building up an archive from scratch into any
 /// arbitrary writer.
-pub struct Builder<W: Write + Unpin + Send + Sync> {
+pub struct Builder<W: AsyncWrite + Unpin + Send + Sync> {
     mode: HeaderMode,
     follow: bool,
     finished: bool,
     obj: Option<W>,
 }
 
-impl<W: Write + Unpin + Send + Sync> Builder<W> {
+impl<W: AsyncWrite + Unpin + Send + Sync> Builder<W> {
     /// Create a new archive builder with the underlying object as the
     /// destination of all data written. The builder will use
     /// `HeaderMode::Complete` by default.
@@ -99,7 +99,7 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { smol::block_on(async {
     /// #
     /// use async_tar::{Builder, Header};
     ///
@@ -116,7 +116,7 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append<R: Read + Unpin + Send>(
+    pub async fn append<R: AsyncRead + Unpin + Send>(
         &mut self,
         header: &Header,
         mut data: R,
@@ -154,7 +154,7 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { smol::block_on(async {
     /// #
     /// use async_tar::{Builder, Header};
     ///
@@ -170,7 +170,7 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// #
     /// # Ok(()) }) }
     /// ```
-    pub async fn append_data<P: AsRef<Path>, R: Read + Unpin + Send>(
+    pub async fn append_data<P: AsRef<Path>, R: AsyncRead + Unpin + Send>(
         &mut self,
         header: &mut Header,
         path: P,
@@ -201,7 +201,7 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { smol::block_on(async {
     /// #
     /// use async_tar::Builder;
     ///
@@ -235,7 +235,7 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { smol::block_on(async {
     /// #
     /// use async_tar::Builder;
     ///
@@ -281,9 +281,9 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { smol::block_on(async {
     /// #
-    /// use async_std::fs::File;
+    /// use smol::fs::File;
     /// use async_tar::Builder;
     ///
     /// let mut ar = Builder::new(Vec::new());
@@ -321,9 +321,9 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { smol::block_on(async {
     /// #
-    /// use async_std::fs;
+    /// use smol::fs;
     /// use async_tar::Builder;
     ///
     /// let mut ar = Builder::new(Vec::new());
@@ -357,9 +357,9 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
     /// # Examples
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { smol::block_on(async {
     /// #
-    /// use async_std::fs;
+    /// use smol::fs;
     /// use async_tar::Builder;
     ///
     /// let mut ar = Builder::new(Vec::new());
@@ -406,9 +406,9 @@ impl<W: Write + Unpin + Send + Sync> Builder<W> {
 }
 
 async fn append(
-    mut dst: &mut (dyn Write + Unpin + Send),
+    mut dst: &mut (dyn AsyncWrite + Unpin + Send),
     header: &Header,
-    mut data: &mut (dyn Read + Unpin + Send),
+    mut data: &mut (dyn AsyncRead + Unpin + Send),
 ) -> io::Result<()> {
     dst.write_all(header.as_bytes()).await?;
     let len = io::copy(&mut data, &mut dst).await?;
@@ -424,7 +424,7 @@ async fn append(
 }
 
 async fn append_path_with_name(
-    dst: &mut (dyn Write + Unpin + Sync + Send),
+    dst: &mut (dyn AsyncWrite + Unpin + Sync + Send),
     path: &Path,
     name: Option<&Path>,
     mode: HeaderMode,
@@ -478,7 +478,7 @@ async fn append_path_with_name(
 }
 
 async fn append_file(
-    dst: &mut (dyn Write + Unpin + Send + Sync),
+    dst: &mut (dyn AsyncWrite + Unpin + Send + Sync),
     path: &Path,
     file: &mut fs::File,
     mode: HeaderMode,
@@ -489,7 +489,7 @@ async fn append_file(
 }
 
 async fn append_dir(
-    dst: &mut (dyn Write + Unpin + Send + Sync),
+    dst: &mut (dyn AsyncWrite + Unpin + Send + Sync),
     path: &Path,
     src_path: &Path,
     mode: HeaderMode,
@@ -515,7 +515,7 @@ fn prepare_header(size: u64, entry_type: EntryType) -> Header {
 }
 
 async fn prepare_header_path(
-    dst: &mut (dyn Write + Unpin + Send + Sync),
+    dst: &mut (dyn AsyncWrite + Unpin + Send + Sync),
     header: &mut Header,
     path: &Path,
 ) -> io::Result<()> {
@@ -544,7 +544,7 @@ async fn prepare_header_path(
 }
 
 async fn prepare_header_link(
-    dst: &mut (dyn Write + Unpin + Send + Sync),
+    dst: &mut (dyn AsyncWrite + Unpin + Send + Sync),
     header: &mut Header,
     link_name: &Path,
 ) -> io::Result<()> {
@@ -562,10 +562,10 @@ async fn prepare_header_link(
 }
 
 async fn append_fs(
-    dst: &mut (dyn Write + Unpin + Send + Sync),
+    dst: &mut (dyn AsyncWrite + Unpin + Send + Sync),
     path: &Path,
     meta: &fs::Metadata,
-    read: &mut (dyn Read + Unpin + Sync + Send),
+    read: &mut (dyn AsyncRead + Unpin + Sync + Send),
     mode: HeaderMode,
     link_name: Option<&Path>,
 ) -> io::Result<()> {
@@ -583,7 +583,7 @@ async fn append_fs(
 }
 
 async fn append_dir_all(
-    dst: &mut (dyn Write + Unpin + Send + Sync),
+    dst: &mut (dyn AsyncWrite + Unpin + Send + Sync),
     path: &Path,
     src_path: &Path,
     mode: HeaderMode,
@@ -593,8 +593,16 @@ async fn append_dir_all(
     while let Some((src, is_dir, is_symlink)) = stack.pop() {
         let dest = path.join(src.strip_prefix(src_path).unwrap());
 
-        // In case of a symlink pointing to a directory, is_dir is false, but src.is_dir() will return true
-        if is_dir || (is_symlink && follow && src.is_dir().await) {
+        //// In case of a symlink pointing to a directory, is_dir is false,
+        // but resolving its metadata will return true.
+        let should_treat_as_dir = is_dir
+            || (is_symlink && follow && {
+                smol::fs::metadata(&src)
+                    .await
+                    .map(|m| m.is_dir())
+                    .unwrap_or(false)
+            });
+        if should_treat_as_dir {
             let mut entries = fs::read_dir(&src).await?;
             while let Some(entry) = entries.next().await {
                 let entry = entry?;
@@ -615,9 +623,9 @@ async fn append_dir_all(
     Ok(())
 }
 
-impl<W: Write + Unpin + Send + Sync> Drop for Builder<W> {
+impl<W: AsyncWrite + Unpin + Send + Sync> Drop for Builder<W> {
     fn drop(&mut self) {
-        async_std::task::block_on(async move {
+        smol::block_on(async move {
             let _ = self.finish().await;
         });
     }
@@ -627,6 +635,6 @@ impl<W: Write + Unpin + Send + Sync> Drop for Builder<W> {
 mod tests {
     use super::*;
 
-    assert_impl_all!(async_std::fs::File: Send, Sync);
-    assert_impl_all!(Builder<async_std::fs::File>: Send, Sync);
+    assert_impl_all!(smol::fs::File: Send, Sync);
+    assert_impl_all!(Builder<smol::fs::File>: Send, Sync);
 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -5,13 +5,13 @@ use std::{
     task::{Context, Poll},
 };
 
-use async_std::{
+use pin_project::pin_project;
+use smol::{
     fs,
     fs::OpenOptions,
-    io::{self, prelude::*, Error, ErrorKind, SeekFrom},
-    path::{Component, Path, PathBuf},
+    io::{self, AsyncRead, AsyncReadExt, AsyncSeekExt, Error, ErrorKind, SeekFrom},
 };
-use pin_project::pin_project;
+use std::path::{Component, Path, PathBuf};
 
 use filetime::{self, FileTime};
 
@@ -22,16 +22,16 @@ use crate::{
 /// A read-only view into an entry of an archive.
 ///
 /// This structure is a window into a portion of a borrowed archive which can
-/// be inspected. It acts as a file handle by implementing the Reader trait. An
+/// be inspected. It acts as a file handle by implementing the AsyncReader trait. An
 /// entry cannot be rewritten once inserted into an archive.
 #[pin_project]
-pub struct Entry<R: Read + Unpin> {
+pub struct Entry<R: AsyncRead + Unpin> {
     #[pin]
     fields: EntryFields<R>,
     _ignored: marker::PhantomData<Archive<R>>,
 }
 
-impl<R: Read + Unpin> fmt::Debug for Entry<R> {
+impl<R: AsyncRead + Unpin> fmt::Debug for Entry<R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Entry")
             .field("fields", &self.fields)
@@ -42,7 +42,7 @@ impl<R: Read + Unpin> fmt::Debug for Entry<R> {
 // private implementation detail of `Entry`, but concrete (no type parameters)
 // and also all-public to be constructed from other modules.
 #[pin_project]
-pub struct EntryFields<R: Read + Unpin> {
+pub struct EntryFields<R: AsyncRead + Unpin> {
     pub long_pathname: Option<Vec<u8>>,
     pub long_linkname: Option<Vec<u8>>,
     pub pax_extensions: Option<Vec<u8>>,
@@ -59,7 +59,7 @@ pub struct EntryFields<R: Read + Unpin> {
     pub(crate) read_state: Option<EntryIo<R>>,
 }
 
-impl<R: Read + Unpin> fmt::Debug for EntryFields<R> {
+impl<R: AsyncRead + Unpin> fmt::Debug for EntryFields<R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EntryFields")
             .field("long_pathname", &self.long_pathname)
@@ -79,12 +79,12 @@ impl<R: Read + Unpin> fmt::Debug for EntryFields<R> {
 }
 
 #[pin_project(project = EntryIoProject)]
-pub enum EntryIo<R: Read + Unpin> {
+pub enum EntryIo<R: AsyncRead + Unpin> {
     Pad(#[pin] io::Take<io::Repeat>),
     Data(#[pin] io::Take<R>),
 }
 
-impl<R: Read + Unpin> fmt::Debug for EntryIo<R> {
+impl<R: AsyncRead + Unpin> fmt::Debug for EntryIo<R> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EntryIo::Pad(_) => write!(f, "EntryIo::Pad"),
@@ -105,7 +105,7 @@ pub enum Unpacked {
     Other,
 }
 
-impl<R: Read + Unpin> Entry<R> {
+impl<R: AsyncRead + Unpin> Entry<R> {
     /// Returns the path name for this entry.
     ///
     /// This method may fail if the pathname is not valid Unicode and this is
@@ -118,7 +118,7 @@ impl<R: Read + Unpin> Entry<R> {
     ///
     /// It is recommended to use this method instead of inspecting the `header`
     /// directly to ensure that various archive formats are handled correctly.
-    pub fn path(&self) -> io::Result<Cow<Path>> {
+    pub fn path(&self) -> io::Result<Cow<'_, Path>> {
         self.fields.path()
     }
 
@@ -128,7 +128,7 @@ impl<R: Read + Unpin> Entry<R> {
     /// separators, and it will not always return the same value as
     /// `self.header().path_bytes()` as some archive formats have support for
     /// longer path names described in separate entries.
-    pub fn path_bytes(&self) -> Cow<[u8]> {
+    pub fn path_bytes(&self) -> Cow<'_, [u8]> {
         self.fields.path_bytes()
     }
 
@@ -145,7 +145,7 @@ impl<R: Read + Unpin> Entry<R> {
     ///
     /// It is recommended to use this method instead of inspecting the `header`
     /// directly to ensure that various archive formats are handled correctly.
-    pub fn link_name(&self) -> io::Result<Option<Cow<Path>>> {
+    pub fn link_name(&self) -> io::Result<Option<Cow<'_, Path>>> {
         self.fields.link_name()
     }
 
@@ -154,7 +154,7 @@ impl<R: Read + Unpin> Entry<R> {
     /// Note that this will not always return the same value as
     /// `self.header().link_name_bytes()` as some archive formats have support for
     /// longer path names described in separate entries.
-    pub fn link_name_bytes(&self) -> Option<Cow<[u8]>> {
+    pub fn link_name_bytes(&self) -> Option<Cow<'_, [u8]>> {
         self.fields.link_name_bytes()
     }
 
@@ -226,11 +226,11 @@ impl<R: Read + Unpin> Entry<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { smol::block_on(async {
     /// #
-    /// use async_std::fs::File;
-    /// use async_std::prelude::*;
+    /// use smol::fs::File;
     /// use async_tar::Archive;
+    /// use smol::stream::StreamExt;
     ///
     /// let mut ar = Archive::new(File::open("foo.tar").await?);
     /// let mut entries = ar.entries()?;
@@ -261,11 +261,11 @@ impl<R: Read + Unpin> Entry<R> {
     /// # Examples
     ///
     /// ```no_run
-    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { async_std::task::block_on(async {
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> { smol::block_on(async {
     /// #
-    /// use async_std::fs::File;
+    /// use smol::fs::File;
     /// use async_tar::Archive;
-    /// use async_std::prelude::*;
+    /// use smol::stream::StreamExt;
     ///
     /// let mut ar = Archive::new(File::open("foo.tar").await?);
     /// let mut entries = ar.entries()?;
@@ -311,7 +311,7 @@ impl<R: Read + Unpin> Entry<R> {
     }
 }
 
-impl<R: Read + Unpin> Read for Entry<R> {
+impl<R: AsyncRead + Unpin> AsyncRead for Entry<R> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -322,7 +322,7 @@ impl<R: Read + Unpin> Read for Entry<R> {
     }
 }
 
-impl<R: Read + Unpin> EntryFields<R> {
+impl<R: AsyncRead + Unpin> EntryFields<R> {
     pub fn from(entry: Entry<R>) -> Self {
         entry.fields
     }
@@ -343,7 +343,7 @@ impl<R: Read + Unpin> EntryFields<R> {
         let mut buf = Vec::with_capacity(cap as usize);
 
         // Copied from futures::ReadToEnd
-        match async_std::task::ready!(poll_read_all_internal(self, cx, &mut buf)) {
+        match smol::ready!(poll_read_all_internal(self, cx, &mut buf)) {
             Ok(_) => Poll::Ready(Ok(buf)),
             Err(err) => Poll::Ready(Err(err)),
         }
@@ -360,7 +360,7 @@ impl<R: Read + Unpin> EntryFields<R> {
         bytes2path(self.path_bytes())
     }
 
-    fn path_bytes(&self) -> Cow<[u8]> {
+    fn path_bytes(&self) -> Cow<'_, [u8]> {
         if let Some(ref bytes) = self.long_pathname {
             if let Some(&0) = bytes.last() {
                 Cow::Borrowed(&bytes[..bytes.len() - 1])
@@ -386,14 +386,14 @@ impl<R: Read + Unpin> EntryFields<R> {
         String::from_utf8_lossy(&self.path_bytes()).to_string()
     }
 
-    fn link_name(&self) -> io::Result<Option<Cow<Path>>> {
+    fn link_name(&self) -> io::Result<Option<Cow<'_, Path>>> {
         match self.link_name_bytes() {
             Some(bytes) => bytes2path(bytes).map(Some),
             None => Ok(None),
         }
     }
 
-    fn link_name_bytes(&self) -> Option<Cow<[u8]>> {
+    fn link_name_bytes(&self) -> Option<Cow<'_, [u8]>> {
         match self.long_linkname {
             Some(ref bytes) => {
                 if let Some(&0) = bytes.last() {
@@ -590,7 +590,7 @@ impl<R: Read + Unpin> EntryFields<R> {
 
             #[cfg(any(unix, target_os = "redox"))]
             async fn symlink(src: &Path, dst: &Path) -> io::Result<()> {
-                async_std::os::unix::fs::symlink(src, dst).await
+                smol::fs::unix::symlink(src, dst).await
             }
         } else if kind.is_pax_global_extensions()
             || kind.is_pax_local_extensions()
@@ -763,7 +763,7 @@ impl<R: Read + Unpin> EntryFields<R> {
         }
 
         #[cfg(all(unix, feature = "xattr"))]
-        async fn set_xattrs<R: Read + Unpin>(
+        async fn set_xattrs<R: AsyncRead + Unpin>(
             me: &mut EntryFields<R>,
             dst: &Path,
         ) -> io::Result<()> {
@@ -812,7 +812,10 @@ impl<R: Read + Unpin> EntryFields<R> {
             not(feature = "xattr"),
             target_arch = "wasm32"
         ))]
-        async fn set_xattrs<R: Read + Unpin>(_: &mut EntryFields<R>, _: &Path) -> io::Result<()> {
+        async fn set_xattrs<R: AsyncRead + Unpin>(
+            _: &mut EntryFields<R>,
+            _: &Path,
+        ) -> io::Result<()> {
             Ok(())
         }
     }
@@ -820,7 +823,7 @@ impl<R: Read + Unpin> EntryFields<R> {
     async fn ensure_dir_created(&self, dst: &Path, dir: &Path) -> io::Result<()> {
         let mut ancestor = dir;
         let mut dirs_to_create = Vec::new();
-        while ancestor.symlink_metadata().await.is_err() {
+        while smol::fs::symlink_metadata(ancestor).await.is_err() {
             dirs_to_create.push(ancestor);
             if let Some(parent) = ancestor.parent() {
                 ancestor = parent;
@@ -839,13 +842,13 @@ impl<R: Read + Unpin> EntryFields<R> {
 
     async fn validate_inside_dst(&self, dst: &Path, file_dst: &Path) -> io::Result<PathBuf> {
         // Abort if target (canonical) parent is outside of `dst`
-        let canon_parent = file_dst.canonicalize().await.map_err(|err| {
+        let canon_parent = smol::fs::canonicalize(file_dst).await.map_err(|err| {
             Error::new(
                 err.kind(),
                 format!("{} while canonicalizing {}", err, file_dst.display()),
             )
         })?;
-        let canon_target = dst.canonicalize().await.map_err(|err| {
+        let canon_target = smol::fs::canonicalize(dst).await.map_err(|err| {
             Error::new(
                 err.kind(),
                 format!("{} while canonicalizing {}", err, dst.display()),
@@ -857,8 +860,7 @@ impl<R: Read + Unpin> EntryFields<R> {
                     "trying to unpack outside of destination path: {}",
                     canon_target.display()
                 ),
-                // TODO: use ErrorKind::InvalidInput here? (minor breaking change)
-                Error::new(ErrorKind::Other, "Invalid argument"),
+                Error::new(ErrorKind::InvalidInput, "Invalid argument"),
             );
             return Err(err.into());
         }
@@ -866,7 +868,7 @@ impl<R: Read + Unpin> EntryFields<R> {
     }
 }
 
-impl<R: Read + Unpin> Read for EntryFields<R> {
+impl<R: AsyncRead + Unpin> AsyncRead for EntryFields<R> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -910,7 +912,7 @@ impl<R: Read + Unpin> Read for EntryFields<R> {
     }
 }
 
-impl<R: Read + Unpin> Read for EntryIo<R> {
+impl<R: AsyncRead + Unpin> AsyncRead for EntryIo<R> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -936,7 +938,7 @@ impl Drop for Guard<'_> {
     }
 }
 
-fn poll_read_all_internal<R: Read + ?Sized>(
+fn poll_read_all_internal<R: AsyncRead + ?Sized>(
     mut rd: Pin<&mut R>,
     cx: &mut Context<'_>,
     buf: &mut Vec<u8>,
@@ -958,7 +960,7 @@ fn poll_read_all_internal<R: Read + ?Sized>(
             }
         }
 
-        match async_std::task::ready!(rd.as_mut().poll_read(cx, &mut g.buf[g.len..])) {
+        match smol::ready!(rd.as_mut().poll_read(cx, &mut g.buf[g.len..])) {
             Ok(0) => {
                 ret = Poll::Ready(Ok(g.len));
                 break;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::{error, fmt};
 
-use async_std::io::{self, Error};
+use smol::io::{self, Error};
 
 #[derive(Debug)]
 pub struct TarError {

--- a/src/header.rs
+++ b/src/header.rs
@@ -5,10 +5,8 @@ use std::os::windows::prelude::*;
 
 use std::{borrow::Cow, fmt, iter, iter::repeat, mem, str};
 
-use async_std::{
-    fs, io,
-    path::{Component, Path, PathBuf},
-};
+use smol::{fs, io};
+use std::path::{Component, Path, PathBuf};
 
 use crate::{other, EntryType};
 
@@ -328,7 +326,7 @@ impl Header {
     ///
     /// Note that this function will convert any `\` characters to directory
     /// separators.
-    pub fn path(&self) -> io::Result<Cow<Path>> {
+    pub fn path(&self) -> io::Result<Cow<'_, Path>> {
         bytes2path(self.path_bytes())
     }
 
@@ -339,7 +337,7 @@ impl Header {
     ///
     /// Note that this function will convert any `\` characters to directory
     /// separators.
-    pub fn path_bytes(&self) -> Cow<[u8]> {
+    pub fn path_bytes(&self) -> Cow<'_, [u8]> {
         if let Some(ustar) = self.as_ustar() {
             ustar.path_bytes()
         } else {
@@ -397,7 +395,7 @@ impl Header {
     ///
     /// Note that this function will convert any `\` characters to directory
     /// separators.
-    pub fn link_name(&self) -> io::Result<Option<Cow<Path>>> {
+    pub fn link_name(&self) -> io::Result<Option<Cow<'_, Path>>> {
         match self.link_name_bytes() {
             Some(bytes) => bytes2path(bytes).map(Some),
             None => Ok(None),
@@ -411,7 +409,7 @@ impl Header {
     ///
     /// Note that this function will convert any `\` characters to directory
     /// separators.
-    pub fn link_name_bytes(&self) -> Option<Cow<[u8]>> {
+    pub fn link_name_bytes(&self) -> Option<Cow<'_, [u8]>> {
         let old = self.as_old();
         if old.linkname[0] == 0 {
             None
@@ -936,7 +934,7 @@ impl fmt::Debug for OldHeader {
 
 impl UstarHeader {
     /// See `Header::path_bytes`
-    pub fn path_bytes(&self) -> Cow<[u8]> {
+    pub fn path_bytes(&self) -> Cow<'_, [u8]> {
         if self.prefix[0] == 0 && !self.name.contains(&b'\\') {
             Cow::Borrowed(truncate(&self.name))
         } else {
@@ -1470,7 +1468,7 @@ fn truncate(slice: &[u8]) -> &[u8] {
 fn copy_into(slot: &mut [u8], bytes: &[u8]) -> io::Result<()> {
     if bytes.len() > slot.len() {
         Err(other("provided value is too long"))
-    } else if bytes.iter().any(|b| *b == 0) {
+    } else if bytes.contains(&0) {
         Err(other("provided value contains a nul byte"))
     } else {
         for (slot, val) in slot.iter_mut().zip(bytes.iter().chain(Some(&0))) {
@@ -1527,7 +1525,7 @@ fn copy_path_into_inner(
         return Err(other("paths in archives must have at least one component"));
     }
     if ends_with_slash(path) {
-        copy(&mut slot, &[b'/'])?;
+        copy(&mut slot, b"/")?;
     }
     return Ok(());
 
@@ -1578,7 +1576,7 @@ fn ends_with_slash(p: &Path) -> bool {
 
 #[cfg(any(unix, target_os = "redox"))]
 fn ends_with_slash(p: &Path) -> bool {
-    p.as_os_str().as_bytes().ends_with(&[b'/'])
+    p.as_os_str().as_bytes().ends_with(b"/")
 }
 
 #[cfg(any(windows, target_arch = "wasm32"))]
@@ -1605,7 +1603,7 @@ pub fn path2bytes(p: &Path) -> io::Result<Cow<[u8]>> {
 
 #[cfg(any(unix, target_os = "redox"))]
 /// On unix this will never fail
-pub fn path2bytes(p: &Path) -> io::Result<Cow<[u8]>> {
+pub fn path2bytes(p: &Path) -> io::Result<Cow<'_, [u8]>> {
     Ok(Cow::Borrowed(p.as_os_str().as_bytes()))
 }
 

--- a/src/pax.rs
+++ b/src/pax.rs
@@ -1,6 +1,6 @@
 use std::{slice, str};
 
-use async_std::io;
+use smol::io;
 
 use crate::other;
 
@@ -18,7 +18,7 @@ pub struct PaxExtension<'entry> {
     value: &'entry [u8],
 }
 
-pub fn pax_extensions(a: &[u8]) -> PaxExtensions {
+pub fn pax_extensions(a: &[u8]) -> PaxExtensions<'_> {
     PaxExtensions {
         data: a.split(|a| *a == b'\n'),
     }

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -4,13 +4,15 @@ extern crate tempfile;
 #[cfg(all(unix, feature = "xattr"))]
 extern crate xattr;
 
-use async_std::{
+use smol::block_on;
+
+use smol::{
     fs::{self, File},
-    io::{self, Cursor, Read, Write},
-    path::{Path, PathBuf},
-    prelude::*,
+    io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, Cursor},
+    stream::StreamExt,
 };
 use std::iter::repeat;
+use std::path::{Path, PathBuf};
 
 use async_tar::{Archive, ArchiveBuilder, Builder, EntryType, Header};
 use filetime::FileTime;
@@ -35,1183 +37,1222 @@ mod header;
 
 /// test that we can concatenate the simple.tar archive and extract the same entries twice when we
 /// use the ignore_zeros option.
-#[async_std::test]
-async fn simple_concat() {
-    let bytes = tar!("simple.tar");
-    let mut archive_bytes = Vec::new();
-    archive_bytes.extend(bytes);
+#[test]
+fn simple_concat() {
+    block_on(async {
+        let bytes = tar!("simple.tar");
+        let mut archive_bytes = Vec::new();
+        archive_bytes.extend(bytes);
 
-    let original_names: Vec<String> = decode_names(Archive::new(Cursor::new(&archive_bytes))).await;
-    let expected: Vec<&str> = original_names.iter().map(|n| n.as_str()).collect();
+        let original_names: Vec<String> =
+            decode_names(Archive::new(Cursor::new(&archive_bytes))).await;
+        let expected: Vec<&str> = original_names.iter().map(|n| n.as_str()).collect();
 
-    // concat two archives (with null in-between);
-    archive_bytes.extend(bytes);
+        // concat two archives (with null in-between);
+        archive_bytes.extend(bytes);
 
-    // test now that when we read the archive, it stops processing at the first zero header.
-    let actual = decode_names(Archive::new(Cursor::new(&archive_bytes))).await;
-    assert_eq!(expected, actual);
+        // test now that when we read the archive, it stops processing at the first zero header.
+        let actual = decode_names(Archive::new(Cursor::new(&archive_bytes))).await;
+        assert_eq!(expected, actual);
 
-    // extend expected by itself.
-    let expected: Vec<&str> = {
-        let mut o = Vec::new();
-        o.extend(&expected);
-        o.extend(&expected);
-        o
-    };
+        // extend expected by itself.
+        let expected: Vec<&str> = {
+            let mut o = Vec::new();
+            o.extend(&expected);
+            o.extend(&expected);
+            o
+        };
 
-    let builder = ArchiveBuilder::new(Cursor::new(&archive_bytes)).set_ignore_zeros(true);
-    let ar = builder.build();
+        let builder = ArchiveBuilder::new(Cursor::new(&archive_bytes)).set_ignore_zeros(true);
+        let ar = builder.build();
 
-    let actual = decode_names(ar).await;
-    assert_eq!(expected, actual);
+        let actual = decode_names(ar).await;
+        assert_eq!(expected, actual);
 
-    async fn decode_names<R>(ar: Archive<R>) -> Vec<String>
-    where
-        R: Read + Unpin + Sync + Send,
-    {
-        let mut names = Vec::new();
+        async fn decode_names<R>(ar: Archive<R>) -> Vec<String>
+        where
+            R: AsyncRead + Unpin + Sync + Send,
+        {
+            let mut names = Vec::new();
+            let mut entries = t!(ar.entries());
+
+            while let Some(entry) = entries.next().await {
+                let e = t!(entry);
+                names.push(t!(::std::str::from_utf8(&e.path_bytes())).to_string());
+            }
+
+            names
+        }
+    });
+}
+
+#[test]
+fn header_impls() {
+    block_on(async {
+        let ar = Archive::new(Cursor::new(tar!("simple.tar")));
+        let hn = Header::new_old();
+        let hnb = hn.as_bytes();
+        let mut entries = t!(ar.entries());
+        while let Some(file) = entries.next().await {
+            let file = t!(file);
+            let h1 = file.header();
+            let h1b = h1.as_bytes();
+            let h2 = h1.clone();
+            let h2b = h2.as_bytes();
+            assert!(h1b[..] == h2b[..] && h2b[..] != hnb[..])
+        }
+    });
+}
+
+#[test]
+fn header_impls_missing_last_header() {
+    block_on(async {
+        let ar = Archive::new(Cursor::new(tar!("simple_missing_last_header.tar")));
+        let hn = Header::new_old();
+        let hnb = hn.as_bytes();
         let mut entries = t!(ar.entries());
 
-        while let Some(entry) = entries.next().await {
-            let e = t!(entry);
-            names.push(t!(::std::str::from_utf8(&e.path_bytes())).to_string());
+        while let Some(file) = entries.next().await {
+            let file = t!(file);
+            let h1 = file.header();
+            let h1b = h1.as_bytes();
+            let h2 = h1.clone();
+            let h2b = h2.as_bytes();
+            assert!(h1b[..] == h2b[..] && h2b[..] != hnb[..])
         }
-
-        names
-    }
+    });
 }
 
-#[async_std::test]
-async fn header_impls() {
-    let ar = Archive::new(Cursor::new(tar!("simple.tar")));
-    let hn = Header::new_old();
-    let hnb = hn.as_bytes();
-    let mut entries = t!(ar.entries());
-    while let Some(file) = entries.next().await {
-        let file = t!(file);
-        let h1 = file.header();
-        let h1b = h1.as_bytes();
-        let h2 = h1.clone();
-        let h2b = h2.as_bytes();
-        assert!(h1b[..] == h2b[..] && h2b[..] != hnb[..])
-    }
+#[test]
+fn reading_files() {
+    block_on(async {
+        let rdr = Cursor::new(tar!("reading_files.tar"));
+        let ar = Archive::new(rdr);
+        let mut entries = t!(ar.entries());
+
+        let mut a = t!(entries.next().await.unwrap());
+        assert_eq!(&*a.header().path_bytes(), b"a");
+        let mut s = String::new();
+        t!(a.read_to_string(&mut s).await);
+        assert_eq!(s, "a\na\na\na\na\na\na\na\na\na\na\n");
+
+        let mut b = t!(entries.next().await.unwrap());
+        assert_eq!(&*b.header().path_bytes(), b"b");
+        s.truncate(0);
+        t!(b.read_to_string(&mut s).await);
+        assert_eq!(s, "b\nb\nb\nb\nb\nb\nb\nb\nb\nb\nb\n");
+
+        assert!(entries.next().await.is_none());
+    });
 }
 
-#[async_std::test]
-async fn header_impls_missing_last_header() {
-    let ar = Archive::new(Cursor::new(tar!("simple_missing_last_header.tar")));
-    let hn = Header::new_old();
-    let hnb = hn.as_bytes();
-    let mut entries = t!(ar.entries());
+#[test]
+fn writing_files() {
+    block_on(async {
+        let mut ar = Builder::new(Vec::new());
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    while let Some(file) = entries.next().await {
-        let file = t!(file);
-        let h1 = file.header();
-        let h1b = h1.as_bytes();
-        let h2 = h1.clone();
-        let h2b = h2.as_bytes();
-        assert!(h1b[..] == h2b[..] && h2b[..] != hnb[..])
-    }
+        let path = td.path().join("test");
+        t!(t!(File::create(&path).await).write_all(b"test").await);
+
+        t!(ar
+            .append_file("test2", &mut t!(File::open(&path).await))
+            .await);
+
+        let data = t!(ar.into_inner().await);
+        let ar = Archive::new(Cursor::new(data));
+        let mut entries = t!(ar.entries());
+        let mut f = t!(entries.next().await.unwrap());
+
+        assert_eq!(&*f.header().path_bytes(), b"test2");
+        assert_eq!(f.header().size().unwrap(), 4);
+        let mut s = String::new();
+        t!(f.read_to_string(&mut s).await);
+        assert_eq!(s, "test");
+
+        assert!(entries.next().await.is_none());
+    });
 }
 
-#[async_std::test]
-async fn reading_files() {
-    let rdr = Cursor::new(tar!("reading_files.tar"));
-    let ar = Archive::new(rdr);
-    let mut entries = t!(ar.entries());
+#[test]
+fn large_filename() {
+    block_on(async {
+        let mut ar = Builder::new(Vec::new());
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let mut a = t!(entries.next().await.unwrap());
-    assert_eq!(&*a.header().path_bytes(), b"a");
-    let mut s = String::new();
-    t!(a.read_to_string(&mut s).await);
-    assert_eq!(s, "a\na\na\na\na\na\na\na\na\na\na\n");
+        let path = td.path().join("test");
+        t!(t!(File::create(&path).await).write_all(b"test").await);
 
-    let mut b = t!(entries.next().await.unwrap());
-    assert_eq!(&*b.header().path_bytes(), b"b");
-    s.truncate(0);
-    t!(b.read_to_string(&mut s).await);
-    assert_eq!(s, "b\nb\nb\nb\nb\nb\nb\nb\nb\nb\nb\n");
+        let filename = "abcd/".repeat(50);
+        let mut header = Header::new_ustar();
+        header.set_path(&filename).unwrap();
+        header.set_metadata(&t!(fs::metadata(&path).await));
+        header.set_cksum();
+        t!(ar.append(&header, &b"test"[..]).await);
+        let too_long = "abcd".repeat(200);
+        t!(ar
+            .append_file(&too_long, &mut t!(File::open(&path).await))
+            .await);
+        t!(ar.append_data(&mut header, &too_long, &b"test"[..]).await);
 
-    assert!(entries.next().await.is_none());
-}
+        let rd = Cursor::new(t!(ar.into_inner().await));
+        let ar = Archive::new(rd);
+        let mut entries = t!(ar.entries());
 
-#[async_std::test]
-async fn writing_files() {
-    let mut ar = Builder::new(Vec::new());
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        // The short entry added with `append`
+        let mut f = entries.next().await.unwrap().unwrap();
+        assert_eq!(&*f.header().path_bytes(), filename.as_bytes());
+        assert_eq!(f.header().size().unwrap(), 4);
+        let mut s = String::new();
+        t!(f.read_to_string(&mut s).await);
+        assert_eq!(s, "test");
 
-    let path = td.path().join("test");
-    t!(t!(File::create(&path).await).write_all(b"test").await);
+        // The long entry added with `append_file`
+        let mut f = entries.next().await.unwrap().unwrap();
+        assert_eq!(&*f.path_bytes(), too_long.as_bytes());
+        assert_eq!(f.header().size().unwrap(), 4);
+        let mut s = String::new();
+        t!(f.read_to_string(&mut s).await);
+        assert_eq!(s, "test");
 
-    t!(ar
-        .append_file("test2", &mut t!(File::open(&path).await))
-        .await);
+        // The long entry added with `append_data`
+        let mut f = entries.next().await.unwrap().unwrap();
+        assert!(f.header().path_bytes().len() < too_long.len());
+        assert_eq!(&*f.path_bytes(), too_long.as_bytes());
+        assert_eq!(f.header().size().unwrap(), 4);
+        let mut s = String::new();
+        t!(f.read_to_string(&mut s).await);
+        assert_eq!(s, "test");
 
-    let data = t!(ar.into_inner().await);
-    let ar = Archive::new(Cursor::new(data));
-    let mut entries = t!(ar.entries());
-    let mut f = t!(entries.next().await.unwrap());
-
-    assert_eq!(&*f.header().path_bytes(), b"test2");
-    assert_eq!(f.header().size().unwrap(), 4);
-    let mut s = String::new();
-    t!(f.read_to_string(&mut s).await);
-    assert_eq!(s, "test");
-
-    assert!(entries.next().await.is_none());
-}
-
-#[async_std::test]
-async fn large_filename() {
-    let mut ar = Builder::new(Vec::new());
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-
-    let path = td.path().join("test");
-    t!(t!(File::create(&path).await).write_all(b"test").await);
-
-    let filename = "abcd/".repeat(50);
-    let mut header = Header::new_ustar();
-    header.set_path(&filename).unwrap();
-    header.set_metadata(&t!(fs::metadata(&path).await));
-    header.set_cksum();
-    t!(ar.append(&header, &b"test"[..]).await);
-    let too_long = "abcd".repeat(200);
-    t!(ar
-        .append_file(&too_long, &mut t!(File::open(&path).await))
-        .await);
-    t!(ar.append_data(&mut header, &too_long, &b"test"[..]).await);
-
-    let rd = Cursor::new(t!(ar.into_inner().await));
-    let ar = Archive::new(rd);
-    let mut entries = t!(ar.entries());
-
-    // The short entry added with `append`
-    let mut f = entries.next().await.unwrap().unwrap();
-    assert_eq!(&*f.header().path_bytes(), filename.as_bytes());
-    assert_eq!(f.header().size().unwrap(), 4);
-    let mut s = String::new();
-    t!(f.read_to_string(&mut s).await);
-    assert_eq!(s, "test");
-
-    // The long entry added with `append_file`
-    let mut f = entries.next().await.unwrap().unwrap();
-    assert_eq!(&*f.path_bytes(), too_long.as_bytes());
-    assert_eq!(f.header().size().unwrap(), 4);
-    let mut s = String::new();
-    t!(f.read_to_string(&mut s).await);
-    assert_eq!(s, "test");
-
-    // The long entry added with `append_data`
-    let mut f = entries.next().await.unwrap().unwrap();
-    assert!(f.header().path_bytes().len() < too_long.len());
-    assert_eq!(&*f.path_bytes(), too_long.as_bytes());
-    assert_eq!(f.header().size().unwrap(), 4);
-    let mut s = String::new();
-    t!(f.read_to_string(&mut s).await);
-    assert_eq!(s, "test");
-
-    assert!(entries.next().await.is_none());
+        assert!(entries.next().await.is_none());
+    });
 }
 
 // This test checks very particular scenario where path component
 // starting with ".." of a long path gets split at 100-byte mark
 // so that ".." goes into header and gets interpreted as parent dir
 // (and rejected) .
-#[async_std::test]
-async fn large_filename_with_dot_dot_at_100_byte_mark() {
-    let mut ar = Builder::new(Vec::new());
+#[test]
+fn large_filename_with_dot_dot_at_100_byte_mark() {
+    block_on(async {
+        let mut ar = Builder::new(Vec::new());
 
-    let mut header = Header::new_gnu();
-    header.set_cksum();
-    header.set_mode(0o644);
-    header.set_size(4);
+        let mut header = Header::new_gnu();
+        header.set_cksum();
+        header.set_mode(0o644);
+        header.set_size(4);
 
-    let mut long_name_with_dot_dot = "tdir/".repeat(19);
-    long_name_with_dot_dot.push_str("tt/..file");
+        let mut long_name_with_dot_dot = "tdir/".repeat(19);
+        long_name_with_dot_dot.push_str("tt/..file");
 
-    t!(ar
-        .append_data(&mut header, &long_name_with_dot_dot, &b"test"[..])
-        .await);
+        t!(ar
+            .append_data(&mut header, &long_name_with_dot_dot, &b"test"[..])
+            .await);
 
-    let rd = Cursor::new(t!(ar.into_inner().await));
-    let ar = Archive::new(rd);
-    let mut entries = t!(ar.entries());
+        let rd = Cursor::new(t!(ar.into_inner().await));
+        let ar = Archive::new(rd);
+        let mut entries = t!(ar.entries());
 
-    let mut f = entries.next().await.unwrap().unwrap();
-    assert_eq!(&*f.path_bytes(), long_name_with_dot_dot.as_bytes());
-    assert_eq!(f.header().size().unwrap(), 4);
-    let mut s = String::new();
-    t!(f.read_to_string(&mut s).await);
-    assert_eq!(s, "test");
-    assert!(entries.next().await.is_none());
+        let mut f = entries.next().await.unwrap().unwrap();
+        assert_eq!(&*f.path_bytes(), long_name_with_dot_dot.as_bytes());
+        assert_eq!(f.header().size().unwrap(), 4);
+        let mut s = String::new();
+        t!(f.read_to_string(&mut s).await);
+        assert_eq!(s, "test");
+        assert!(entries.next().await.is_none());
+    });
 }
 
-#[async_std::test]
-async fn reading_entries() {
-    let rdr = Cursor::new(tar!("reading_files.tar"));
-    let ar = Archive::new(rdr);
-    let mut entries = t!(ar.entries());
-    let mut a = t!(entries.next().await.unwrap());
-    assert_eq!(&*a.header().path_bytes(), b"a");
-    let mut s = String::new();
-    t!(a.read_to_string(&mut s).await);
-    assert_eq!(s, "a\na\na\na\na\na\na\na\na\na\na\n");
-    s.truncate(0);
-    t!(a.read_to_string(&mut s).await);
-    assert_eq!(s, "");
-    let mut b = t!(entries.next().await.unwrap());
+#[test]
+fn reading_entries() {
+    block_on(async {
+        let rdr = Cursor::new(tar!("reading_files.tar"));
+        let ar = Archive::new(rdr);
+        let mut entries = t!(ar.entries());
+        let mut a = t!(entries.next().await.unwrap());
+        assert_eq!(&*a.header().path_bytes(), b"a");
+        let mut s = String::new();
+        t!(a.read_to_string(&mut s).await);
+        assert_eq!(s, "a\na\na\na\na\na\na\na\na\na\na\n");
+        s.truncate(0);
+        t!(a.read_to_string(&mut s).await);
+        assert_eq!(s, "");
+        let mut b = t!(entries.next().await.unwrap());
 
-    assert_eq!(&*b.header().path_bytes(), b"b");
-    s.truncate(0);
-    t!(b.read_to_string(&mut s).await);
-    assert_eq!(s, "b\nb\nb\nb\nb\nb\nb\nb\nb\nb\nb\n");
-    assert!(entries.next().await.is_none());
+        assert_eq!(&*b.header().path_bytes(), b"b");
+        s.truncate(0);
+        t!(b.read_to_string(&mut s).await);
+        assert_eq!(s, "b\nb\nb\nb\nb\nb\nb\nb\nb\nb\nb\n");
+        assert!(entries.next().await.is_none());
+    });
 }
 
 async fn check_dirtree(td: &TempDir) {
     let dir_a = td.path().join("a");
     let dir_b = td.path().join("a/b");
     let file_c = td.path().join("a/c");
-    assert!(
-        fs::metadata(&dir_a)
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(&dir_b)
-            .await
-            .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(&file_c)
-            .await
-            .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+    assert!(fs::metadata(&dir_a)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false));
+    assert!(fs::metadata(&dir_b)
+        .await
+        .map(|m| m.is_dir())
+        .unwrap_or(false));
+    assert!(fs::metadata(&file_c)
+        .await
+        .map(|m| m.is_file())
+        .unwrap_or(false));
 }
 
-#[async_std::test]
-async fn extracting_directories() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let rdr = Cursor::new(tar!("directory.tar"));
-    let ar = Archive::new(rdr);
-    t!(ar.unpack(td.path()).await);
-    check_dirtree(&td).await;
+#[test]
+fn extracting_directories() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let rdr = Cursor::new(tar!("directory.tar"));
+        let ar = Archive::new(rdr);
+        t!(ar.unpack(td.path()).await);
+        check_dirtree(&td).await;
+    });
 }
 
-#[async_std::test]
 #[cfg(all(unix, feature = "xattr"))]
-async fn xattrs() {
-    // If /tmp is a tmpfs, xattr will fail
-    // The xattr crate's unit tests also use /var/tmp for this reason
-    let td = t!(TempBuilder::new()
-        .prefix("async-tar")
-        .tempdir_in("/var/tmp"));
-    let rdr = Cursor::new(tar!("xattrs.tar"));
-    let builder = ArchiveBuilder::new(rdr).set_unpack_xattrs(true);
-    let ar = builder.build();
-    t!(ar.unpack(td.path()).await);
+fn xattrs() {
+    block_on(async {
+        // If /tmp is a tmpfs, xattr will fail
+        // The xattr crate's unit tests also use /var/tmp for this reason
+        let td = t!(TempBuilder::new()
+            .prefix("async-tar")
+            .tempdir_in("/var/tmp"));
+        let rdr = Cursor::new(tar!("xattrs.tar"));
+        let builder = ArchiveBuilder::new(rdr).set_unpack_xattrs(true);
+        let ar = builder.build();
+        t!(ar.unpack(td.path()).await);
 
-    let val = xattr::get(td.path().join("a/b"), "user.pax.flags").unwrap();
-    assert_eq!(val.unwrap(), b"epm");
+        let val = xattr::get(td.path().join("a/b"), "user.pax.flags").unwrap();
+        assert_eq!(val.unwrap(), b"epm");
+    });
 }
 
-#[async_std::test]
+#[test]
 #[cfg(all(unix, feature = "xattr"))]
-async fn no_xattrs() {
-    // If /tmp is a tmpfs, xattr will fail
-    // The xattr crate's unit tests also use /var/tmp for this reason
-    let td = t!(TempBuilder::new()
-        .prefix("async-tar")
-        .tempdir_in("/var/tmp"));
-    let rdr = Cursor::new(tar!("xattrs.tar"));
-    let builder = ArchiveBuilder::new(rdr).set_unpack_xattrs(false);
-    let ar = builder.build();
-    t!(ar.unpack(td.path()).await);
+fn no_xattrs() {
+    block_on(async {
+        // If /tmp is a tmpfs, xattr will fail
+        // The xattr crate's unit tests also use /var/tmp for this reason
+        let td = t!(TempBuilder::new()
+            .prefix("async-tar")
+            .tempdir_in("/var/tmp"));
+        let rdr = Cursor::new(tar!("xattrs.tar"));
+        let builder = ArchiveBuilder::new(rdr).set_unpack_xattrs(false);
+        let ar = builder.build();
+        t!(ar.unpack(td.path()).await);
 
-    assert_eq!(
-        xattr::get(td.path().join("a/b"), "user.pax.flags").unwrap(),
-        None
-    );
+        assert_eq!(
+            xattr::get(td.path().join("a/b"), "user.pax.flags").unwrap(),
+            None
+        );
+    });
 }
 
-#[async_std::test]
-async fn writing_and_extracting_directories() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+#[test]
+fn writing_and_extracting_directories() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let mut ar = Builder::new(Vec::new());
-    let tmppath = td.path().join("tmpfile");
-    t!(t!(File::create(&tmppath).await).write_all(b"c").await);
-    t!(ar.append_dir("a", ".").await);
-    t!(ar.append_dir("a/b", ".").await);
-    t!(ar
-        .append_file("a/c", &mut t!(File::open(&tmppath).await))
-        .await);
-    t!(ar.finish().await);
+        let mut ar = Builder::new(Vec::new());
+        let tmppath = td.path().join("tmpfile");
+        t!(t!(File::create(&tmppath).await).write_all(b"c").await);
+        t!(ar.append_dir("a", ".").await);
+        t!(ar.append_dir("a/b", ".").await);
+        t!(ar
+            .append_file("a/c", &mut t!(File::open(&tmppath).await))
+            .await);
+        t!(ar.finish().await);
 
-    let rdr = Cursor::new(t!(ar.into_inner().await));
-    let ar = Archive::new(rdr);
-    t!(ar.unpack(td.path()).await);
-    check_dirtree(&td).await;
+        let rdr = Cursor::new(t!(ar.into_inner().await));
+        let ar = Archive::new(rdr);
+        t!(ar.unpack(td.path()).await);
+        check_dirtree(&td).await;
+    });
 }
 
-#[async_std::test]
-async fn writing_directories_recursively() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+#[test]
+fn writing_directories_recursively() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let base_dir = td.path().join("base");
-    t!(fs::create_dir(&base_dir).await);
-    t!(t!(File::create(base_dir.join("file1")).await)
-        .write_all(b"file1")
-        .await);
-    let sub_dir = base_dir.join("sub");
-    t!(fs::create_dir(&sub_dir).await);
-    t!(t!(File::create(sub_dir.join("file2")).await)
-        .write_all(b"file2")
-        .await);
+        let base_dir = td.path().join("base");
+        t!(fs::create_dir(&base_dir).await);
+        t!(t!(File::create(base_dir.join("file1")).await)
+            .write_all(b"file1")
+            .await);
+        let sub_dir = base_dir.join("sub");
+        t!(fs::create_dir(&sub_dir).await);
+        t!(t!(File::create(sub_dir.join("file2")).await)
+            .write_all(b"file2")
+            .await);
 
-    let mut ar = Builder::new(Vec::new());
-    t!(ar.append_dir_all("foobar", base_dir).await);
-    let data = t!(ar.into_inner().await);
+        let mut ar = Builder::new(Vec::new());
+        t!(ar.append_dir_all("foobar", base_dir).await);
+        let data = t!(ar.into_inner().await);
 
-    let ar = Archive::new(Cursor::new(data));
-    t!(ar.unpack(td.path()).await);
-    let base_dir = td.path().join("foobar");
-    assert!(
-        fs::metadata(&base_dir)
+        let ar = Archive::new(Cursor::new(data));
+        t!(ar.unpack(td.path()).await);
+        let base_dir = td.path().join("foobar");
+        assert!(fs::metadata(&base_dir)
             .await
             .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
-    let file1_path = base_dir.join("file1");
-    assert!(
-        fs::metadata(&file1_path)
+            .unwrap_or(false));
+        let file1_path = base_dir.join("file1");
+        assert!(fs::metadata(&file1_path)
             .await
             .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
-    let sub_dir = base_dir.join("sub");
-    assert!(
-        fs::metadata(&sub_dir)
+            .unwrap_or(false));
+        let sub_dir = base_dir.join("sub");
+        assert!(fs::metadata(&sub_dir)
             .await
             .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
-    let file2_path = sub_dir.join("file2");
-    assert!(
-        fs::metadata(&file2_path)
+            .unwrap_or(false));
+        let file2_path = sub_dir.join("file2");
+        assert!(fs::metadata(&file2_path)
             .await
             .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+            .unwrap_or(false));
+    });
 }
 
-#[async_std::test]
-async fn append_dir_all_blank_dest() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+#[test]
+fn append_dir_all_blank_dest() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let base_dir = td.path().join("base");
-    t!(fs::create_dir(&base_dir).await);
-    t!(t!(File::create(base_dir.join("file1")).await)
-        .write_all(b"file1")
-        .await);
-    let sub_dir = base_dir.join("sub");
-    t!(fs::create_dir(&sub_dir).await);
-    t!(t!(File::create(sub_dir.join("file2")).await)
-        .write_all(b"file2")
-        .await);
+        let base_dir = td.path().join("base");
+        t!(fs::create_dir(&base_dir).await);
+        t!(t!(File::create(base_dir.join("file1")).await)
+            .write_all(b"file1")
+            .await);
+        let sub_dir = base_dir.join("sub");
+        t!(fs::create_dir(&sub_dir).await);
+        t!(t!(File::create(sub_dir.join("file2")).await)
+            .write_all(b"file2")
+            .await);
 
-    let mut ar = Builder::new(Vec::new());
-    t!(ar.append_dir_all("", base_dir).await);
-    let data = t!(ar.into_inner().await);
+        let mut ar = Builder::new(Vec::new());
+        t!(ar.append_dir_all("", base_dir).await);
+        let data = t!(ar.into_inner().await);
 
-    let ar = Archive::new(Cursor::new(data));
-    t!(ar.unpack(td.path()).await);
-    let base_dir = td.path();
-    assert!(
-        fs::metadata(&base_dir)
+        let ar = Archive::new(Cursor::new(data));
+        t!(ar.unpack(td.path()).await);
+        let base_dir = td.path();
+        assert!(fs::metadata(&base_dir)
             .await
             .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
-    let file1_path = base_dir.join("file1");
-    assert!(
-        fs::metadata(&file1_path)
+            .unwrap_or(false));
+        let file1_path = base_dir.join("file1");
+        assert!(fs::metadata(&file1_path)
             .await
             .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
-    let sub_dir = base_dir.join("sub");
-    assert!(
-        fs::metadata(&sub_dir)
+            .unwrap_or(false));
+        let sub_dir = base_dir.join("sub");
+        assert!(fs::metadata(&sub_dir)
             .await
             .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
-    let file2_path = sub_dir.join("file2");
-    assert!(
-        fs::metadata(&file2_path)
+            .unwrap_or(false));
+        let file2_path = sub_dir.join("file2");
+        assert!(fs::metadata(&file2_path)
             .await
             .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+            .unwrap_or(false));
+    });
 }
 
-#[async_std::test]
-async fn append_dir_all_does_not_work_on_non_directory() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let path = td.path().join("test");
-    t!(t!(File::create(&path).await).write_all(b"test").await);
+#[test]
+fn append_dir_all_does_not_work_on_non_directory() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let path = td.path().join("test");
+        t!(t!(File::create(&path).await).write_all(b"test").await);
 
-    let mut ar = Builder::new(Vec::new());
-    let result = ar.append_dir_all("test", path).await;
-    assert!(result.is_err());
+        let mut ar = Builder::new(Vec::new());
+        let result = ar.append_dir_all("test", path).await;
+        assert!(result.is_err());
+    });
 }
 
-#[async_std::test]
-async fn extracting_duplicate_dirs() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let rdr = Cursor::new(tar!("duplicate_dirs.tar"));
-    let ar = Archive::new(rdr);
-    t!(ar.unpack(td.path()).await);
+#[test]
+fn extracting_duplicate_dirs() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let rdr = Cursor::new(tar!("duplicate_dirs.tar"));
+        let ar = Archive::new(rdr);
+        t!(ar.unpack(td.path()).await);
 
-    let some_dir = td.path().join("some_dir");
-    assert!(
-        fs::metadata(&some_dir)
+        let some_dir = td.path().join("some_dir");
+        assert!(fs::metadata(&some_dir)
             .await
             .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
+            .unwrap_or(false));
+    });
 }
 
-#[async_std::test]
-async fn unpack_old_style_bsd_dir() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+#[test]
+fn unpack_old_style_bsd_dir() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let mut ar = Builder::new(Vec::new());
+        let mut ar = Builder::new(Vec::new());
 
-    let mut header = Header::new_old();
-    header.set_entry_type(EntryType::Regular);
-    t!(header.set_path("testdir/"));
-    header.set_size(0);
-    header.set_cksum();
-    t!(ar.append(&header, &mut io::empty()).await);
+        let mut header = Header::new_old();
+        header.set_entry_type(EntryType::Regular);
+        t!(header.set_path("testdir/"));
+        header.set_size(0);
+        header.set_cksum();
+        t!(ar.append(&header, &mut io::empty()).await);
 
-    // Extracting
-    let rdr = Cursor::new(t!(ar.into_inner().await));
-    let ar = Archive::new(rdr);
-    t!(ar.clone().unpack(td.path()).await);
+        // Extracting
+        let rdr = Cursor::new(t!(ar.into_inner().await));
+        let ar = Archive::new(rdr);
+        t!(ar.clone().unpack(td.path()).await);
 
-    // Iterating
-    let rdr = Cursor::new(ar.into_inner().map_err(|_| ()).unwrap().into_inner());
-    let ar = Archive::new(rdr);
-    assert!(t!(ar.entries()).all(|fr| fr.is_ok()).await);
+        // Iterating
+        let rdr = Cursor::new(ar.into_inner().map_err(|_| ()).unwrap().into_inner());
+        let ar = Archive::new(rdr);
+        assert!(t!(ar.entries()).all(|fr| fr.is_ok()).await);
 
-    assert!(td.path().join("testdir").is_dir());
+        assert!(td.path().join("testdir").is_dir());
+    });
 }
 
-#[async_std::test]
-async fn handling_incorrect_file_size() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+#[test]
+fn handling_incorrect_file_size() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let mut ar = Builder::new(Vec::new());
+        let mut ar = Builder::new(Vec::new());
 
-    let path = td.path().join("tmpfile");
-    t!(File::create(&path).await);
-    let mut file = t!(File::open(&path).await);
-    let mut header = Header::new_old();
-    t!(header.set_path("somepath"));
-    header.set_metadata(&t!(file.metadata().await));
-    header.set_size(2048); // past the end of file null blocks
-    header.set_cksum();
-    t!(ar.append(&header, &mut file).await);
+        let path = td.path().join("tmpfile");
+        t!(File::create(&path).await);
+        let mut file = t!(File::open(&path).await);
+        let mut header = Header::new_old();
+        t!(header.set_path("somepath"));
+        header.set_metadata(&t!(file.metadata().await));
+        header.set_size(2048); // past the end of file null blocks
+        header.set_cksum();
+        t!(ar.append(&header, &mut file).await);
 
-    // Extracting
-    let rdr = Cursor::new(t!(ar.into_inner().await));
-    let ar = Archive::new(rdr);
-    assert!(ar.clone().unpack(td.path()).await.is_err());
+        // Extracting
+        let rdr = Cursor::new(t!(ar.into_inner().await));
+        let ar = Archive::new(rdr);
+        assert!(ar.clone().unpack(td.path()).await.is_err());
 
-    // Iterating
-    let rdr = Cursor::new(ar.into_inner().map_err(|_| ()).unwrap().into_inner());
-    let ar = Archive::new(rdr);
-    assert!(t!(ar.entries()).any(|fr| fr.is_err()).await);
+        // Iterating
+        let rdr = Cursor::new(ar.into_inner().map_err(|_| ()).unwrap().into_inner());
+        let ar = Archive::new(rdr);
+        assert!(t!(ar.entries()).any(|fr| fr.is_err()).await);
+    });
 }
 
-#[async_std::test]
-async fn extracting_malicious_tarball() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+#[test]
+fn extracting_malicious_tarball() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let mut evil_tar = Vec::new();
+        let mut evil_tar = Vec::new();
 
-    {
-        let mut a = Builder::new(&mut evil_tar);
-        async fn append<R: Write + Unpin + Send + Sync>(a: &mut Builder<R>, path: &'static str) {
-            let mut header = Header::new_gnu();
-            assert!(header.set_path(path).is_err(), "was ok: {:?}", path);
-            {
-                let h = header.as_gnu_mut().unwrap();
-                for (a, b) in h.name.iter_mut().zip(path.as_bytes()) {
-                    *a = *b;
+        {
+            let mut a = Builder::new(&mut evil_tar);
+            async fn append<R: AsyncWrite + Unpin + Send + Sync>(
+                a: &mut Builder<R>,
+                path: &'static str,
+            ) {
+                let mut header = Header::new_gnu();
+                assert!(header.set_path(path).is_err(), "was ok: {:?}", path);
+                {
+                    let h = header.as_gnu_mut().unwrap();
+                    for (a, b) in h.name.iter_mut().zip(path.as_bytes()) {
+                        *a = *b;
+                    }
                 }
+                header.set_size(1);
+                header.set_cksum();
+                t!(a.append(&header, io::repeat(1).take(1)).await);
             }
-            header.set_size(1);
-            header.set_cksum();
-            t!(a.append(&header, io::repeat(1).take(1)).await);
+
+            append(&mut a, "/tmp/abs_evil.txt").await;
+            append(&mut a, "//tmp/abs_evil2.txt").await;
+            append(&mut a, "///tmp/abs_evil3.txt").await;
+            append(&mut a, "/./tmp/abs_evil4.txt").await;
+            append(&mut a, "//./tmp/abs_evil5.txt").await;
+            append(&mut a, "///./tmp/abs_evil6.txt").await;
+            append(&mut a, "/../tmp/rel_evil.txt").await;
+            append(&mut a, "../rel_evil2.txt").await;
+            append(&mut a, "./../rel_evil3.txt").await;
+            append(&mut a, "some/../../rel_evil4.txt").await;
+            append(&mut a, "").await;
+            append(&mut a, "././//./..").await;
+            append(&mut a, "..").await;
+            append(&mut a, "/////////..").await;
+            append(&mut a, "/////////").await;
         }
 
-        append(&mut a, "/tmp/abs_evil.txt").await;
-        append(&mut a, "//tmp/abs_evil2.txt").await;
-        append(&mut a, "///tmp/abs_evil3.txt").await;
-        append(&mut a, "/./tmp/abs_evil4.txt").await;
-        append(&mut a, "//./tmp/abs_evil5.txt").await;
-        append(&mut a, "///./tmp/abs_evil6.txt").await;
-        append(&mut a, "/../tmp/rel_evil.txt").await;
-        append(&mut a, "../rel_evil2.txt").await;
-        append(&mut a, "./../rel_evil3.txt").await;
-        append(&mut a, "some/../../rel_evil4.txt").await;
-        append(&mut a, "").await;
-        append(&mut a, "././//./..").await;
-        append(&mut a, "..").await;
-        append(&mut a, "/////////..").await;
-        append(&mut a, "/////////").await;
-    }
+        let ar = Archive::new(&evil_tar[..]);
+        t!(ar.unpack(td.path()).await);
 
-    let ar = Archive::new(&evil_tar[..]);
-    t!(ar.unpack(td.path()).await);
-
-    assert!(fs::metadata("/tmp/abs_evil.txt").await.is_err());
-    assert!(fs::metadata("/tmp/abs_evil.txt2").await.is_err());
-    assert!(fs::metadata("/tmp/abs_evil.txt3").await.is_err());
-    assert!(fs::metadata("/tmp/abs_evil.txt4").await.is_err());
-    assert!(fs::metadata("/tmp/abs_evil.txt5").await.is_err());
-    assert!(fs::metadata("/tmp/abs_evil.txt6").await.is_err());
-    assert!(fs::metadata("/tmp/rel_evil.txt").await.is_err());
-    assert!(fs::metadata("/tmp/rel_evil.txt").await.is_err());
-    assert!(
-        fs::metadata(td.path().join("../tmp/rel_evil.txt"))
+        assert!(fs::metadata("/tmp/abs_evil.txt").await.is_err());
+        assert!(fs::metadata("/tmp/abs_evil.txt2").await.is_err());
+        assert!(fs::metadata("/tmp/abs_evil.txt3").await.is_err());
+        assert!(fs::metadata("/tmp/abs_evil.txt4").await.is_err());
+        assert!(fs::metadata("/tmp/abs_evil.txt5").await.is_err());
+        assert!(fs::metadata("/tmp/abs_evil.txt6").await.is_err());
+        assert!(fs::metadata("/tmp/rel_evil.txt").await.is_err());
+        assert!(fs::metadata("/tmp/rel_evil.txt").await.is_err());
+        assert!(fs::metadata(td.path().join("../tmp/rel_evil.txt"))
             .await
-            .is_err()
-    );
-    assert!(
-        fs::metadata(td.path().join("../rel_evil2.txt"))
+            .is_err());
+        assert!(fs::metadata(td.path().join("../rel_evil2.txt"))
             .await
-            .is_err()
-    );
-    assert!(
-        fs::metadata(td.path().join("../rel_evil3.txt"))
+            .is_err());
+        assert!(fs::metadata(td.path().join("../rel_evil3.txt"))
             .await
-            .is_err()
-    );
-    assert!(
-        fs::metadata(td.path().join("../rel_evil4.txt"))
+            .is_err());
+        assert!(fs::metadata(td.path().join("../rel_evil4.txt"))
             .await
-            .is_err()
-    );
+            .is_err());
 
-    // The `some` subdirectory should not be created because the only
-    // filename that references this has '..'.
-    assert!(fs::metadata(td.path().join("some")).await.is_err());
+        // The `some` subdirectory should not be created because the only
+        // filename that references this has '..'.
+        assert!(fs::metadata(td.path().join("some")).await.is_err());
 
-    // The `tmp` subdirectory should be created and within this
-    // subdirectory, there should be files named `abs_evil.txt` through
-    // `abs_evil6.txt`.
-    let tmp_root = td.path().join("tmp");
+        // The `tmp` subdirectory should be created and within this
+        // subdirectory, there should be files named `abs_evil.txt` through
+        // `abs_evil6.txt`.
+        let tmp_root = td.path().join("tmp");
 
-    assert!(
-        fs::metadata(&tmp_root)
+        assert!(fs::metadata(&tmp_root)
             .await
             .map(|m| m.is_dir())
-            .unwrap_or(false)
-    );
+            .unwrap_or(false));
 
-    let mut entries = fs::read_dir(&tmp_root).await.unwrap();
-    while let Some(entry) = entries.next().await {
-        let entry = entry.unwrap();
-        println!("- {:?}", entry.file_name());
-    }
+        let mut entries = fs::read_dir(&tmp_root).await.unwrap();
+        while let Some(entry) = entries.next().await {
+            let entry = entry.unwrap();
+            println!("- {:?}", entry.file_name());
+        }
 
-    assert!(
-        fs::metadata(tmp_root.join("abs_evil.txt"))
+        assert!(fs::metadata(tmp_root.join("abs_evil.txt"))
             .await
             .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+            .unwrap_or(false));
 
-    // not present due to // being interpreted differently on windows
-    #[cfg(not(target_os = "windows"))]
-    assert!(
-        fs::metadata(tmp_root.join("abs_evil2.txt"))
+        // not present due to // being interpreted differently on windows
+        #[cfg(not(target_os = "windows"))]
+        assert!(fs::metadata(tmp_root.join("abs_evil2.txt"))
             .await
             .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(tmp_root.join("abs_evil3.txt"))
+            .unwrap_or(false));
+        assert!(fs::metadata(tmp_root.join("abs_evil3.txt"))
             .await
             .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(tmp_root.join("abs_evil4.txt"))
+            .unwrap_or(false));
+        assert!(fs::metadata(tmp_root.join("abs_evil4.txt"))
             .await
             .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+            .unwrap_or(false));
 
-    // not present due to // being interpreted differently on windows
-    #[cfg(not(target_os = "windows"))]
-    assert!(
-        fs::metadata(tmp_root.join("abs_evil5.txt"))
+        // not present due to // being interpreted differently on windows
+        #[cfg(not(target_os = "windows"))]
+        assert!(fs::metadata(tmp_root.join("abs_evil5.txt"))
             .await
             .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
-    assert!(
-        fs::metadata(tmp_root.join("abs_evil6.txt"))
+            .unwrap_or(false));
+        assert!(fs::metadata(tmp_root.join("abs_evil6.txt"))
             .await
             .map(|m| m.is_file())
-            .unwrap_or(false)
-    );
+            .unwrap_or(false));
+    });
 }
 
-#[async_std::test]
-async fn octal_spaces() {
-    let rdr = Cursor::new(tar!("spaces.tar"));
-    let ar = Archive::new(rdr);
+#[test]
+fn octal_spaces() {
+    block_on(async {
+        let rdr = Cursor::new(tar!("spaces.tar"));
+        let ar = Archive::new(rdr);
 
-    let entry = ar.entries().unwrap().next().await.unwrap().unwrap();
-    assert_eq!(entry.header().mode().unwrap() & 0o777, 0o777);
-    assert_eq!(entry.header().uid().unwrap(), 0);
-    assert_eq!(entry.header().gid().unwrap(), 0);
-    assert_eq!(entry.header().size().unwrap(), 2);
-    assert_eq!(entry.header().mtime().unwrap(), 0o12_440_016_664);
-    assert_eq!(entry.header().cksum().unwrap(), 0o4253);
+        let entry = ar.entries().unwrap().next().await.unwrap().unwrap();
+        assert_eq!(entry.header().mode().unwrap() & 0o777, 0o777);
+        assert_eq!(entry.header().uid().unwrap(), 0);
+        assert_eq!(entry.header().gid().unwrap(), 0);
+        assert_eq!(entry.header().size().unwrap(), 2);
+        assert_eq!(entry.header().mtime().unwrap(), 0o12_440_016_664);
+        assert_eq!(entry.header().cksum().unwrap(), 0o4253);
+    });
 }
 
-#[async_std::test]
-async fn extracting_malformed_tar_null_blocks() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+#[test]
+fn extracting_malformed_tar_null_blocks() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let mut ar = Builder::new(Vec::new());
+        let mut ar = Builder::new(Vec::new());
 
-    let path1 = td.path().join("tmpfile1");
-    let path2 = td.path().join("tmpfile2");
-    t!(File::create(&path1).await);
-    t!(File::create(&path2).await);
-    t!(ar
-        .append_file("tmpfile1", &mut t!(File::open(&path1).await))
-        .await);
-    let mut data = t!(ar.into_inner().await);
-    let amt = data.len();
-    data.truncate(amt - 512);
-    let mut ar = Builder::new(data);
-    t!(ar
-        .append_file("tmpfile2", &mut t!(File::open(&path2).await))
-        .await);
-    t!(ar.finish().await);
+        let path1 = td.path().join("tmpfile1");
+        let path2 = td.path().join("tmpfile2");
+        t!(File::create(&path1).await);
+        t!(File::create(&path2).await);
+        t!(ar
+            .append_file("tmpfile1", &mut t!(File::open(&path1).await))
+            .await);
+        let mut data = t!(ar.into_inner().await);
+        let amt = data.len();
+        data.truncate(amt - 512);
+        let mut ar = Builder::new(data);
+        t!(ar
+            .append_file("tmpfile2", &mut t!(File::open(&path2).await))
+            .await);
+        t!(ar.finish().await);
 
-    let data = t!(ar.into_inner().await);
-    let ar = Archive::new(&data[..]);
-    assert!(ar.unpack(td.path()).await.is_ok());
+        let data = t!(ar.into_inner().await);
+        let ar = Archive::new(&data[..]);
+        assert!(ar.unpack(td.path()).await.is_ok());
+    });
 }
 
-#[async_std::test]
-async fn empty_filename() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let rdr = Cursor::new(tar!("empty_filename.tar"));
-    let ar = Archive::new(rdr);
-    assert!(ar.unpack(td.path()).await.is_ok());
+#[test]
+fn empty_filename() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let rdr = Cursor::new(tar!("empty_filename.tar"));
+        let ar = Archive::new(rdr);
+        assert!(ar.unpack(td.path()).await.is_ok());
+    });
 }
 
-#[async_std::test]
-async fn file_times() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let rdr = Cursor::new(tar!("file_times.tar"));
-    let ar = Archive::new(rdr);
-    t!(ar.unpack(td.path()).await);
+#[test]
+fn file_times() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let rdr = Cursor::new(tar!("file_times.tar"));
+        let ar = Archive::new(rdr);
+        t!(ar.unpack(td.path()).await);
 
-    let meta = fs::metadata(td.path().join("a")).await.unwrap();
-    let mtime = FileTime::from_last_modification_time(&meta);
-    let atime = FileTime::from_last_access_time(&meta);
-    assert_eq!(mtime.unix_seconds(), 1_000_000_000);
-    assert_eq!(mtime.nanoseconds(), 0);
-    assert_eq!(atime.unix_seconds(), 1_000_000_000);
-    assert_eq!(atime.nanoseconds(), 0);
+        let meta = fs::metadata(td.path().join("a")).await.unwrap();
+        let mtime = FileTime::from_last_modification_time(&meta);
+        let atime = FileTime::from_last_access_time(&meta);
+        assert_eq!(mtime.unix_seconds(), 1_000_000_000);
+        assert_eq!(mtime.nanoseconds(), 0);
+        assert_eq!(atime.unix_seconds(), 1_000_000_000);
+        assert_eq!(atime.nanoseconds(), 0);
+    });
 }
 
-#[async_std::test]
-async fn backslash_treated_well() {
-    // Insert a file into an archive with a backslash
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let mut ar = Builder::new(Vec::<u8>::new());
-    t!(ar.append_dir("foo\\bar", td.path()).await);
-    let ar = Archive::new(Cursor::new(t!(ar.into_inner().await)));
-    let f = t!(t!(ar.entries()).next().await.unwrap());
-    if cfg!(unix) {
+#[test]
+fn backslash_treated_well() {
+    block_on(async {
+        // Insert a file into an archive with a backslash
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let mut ar = Builder::new(Vec::<u8>::new());
+        t!(ar.append_dir("foo\\bar", td.path()).await);
+        let ar = Archive::new(Cursor::new(t!(ar.into_inner().await)));
+        let f = t!(t!(ar.entries()).next().await.unwrap());
+        if cfg!(unix) {
+            assert_eq!(t!(f.header().path()).to_str(), Some("foo\\bar"));
+        } else {
+            assert_eq!(t!(f.header().path()).to_str(), Some("foo/bar"));
+        }
+
+        // Unpack an archive with a backslash in the name
+        let mut ar = Builder::new(Vec::<u8>::new());
+        let mut header = Header::new_gnu();
+        header.set_metadata(&t!(fs::metadata(td.path()).await));
+        header.set_size(0);
+        for (a, b) in header.as_old_mut().name.iter_mut().zip(b"foo\\bar\x00") {
+            *a = *b;
+        }
+        header.set_cksum();
+        t!(ar.append(&header, &mut io::empty()).await);
+        let data = t!(ar.into_inner().await);
+        let ar = Archive::new(&data[..]);
+        let f = t!(t!(ar.entries()).next().await.unwrap());
         assert_eq!(t!(f.header().path()).to_str(), Some("foo\\bar"));
-    } else {
-        assert_eq!(t!(f.header().path()).to_str(), Some("foo/bar"));
-    }
 
-    // Unpack an archive with a backslash in the name
-    let mut ar = Builder::new(Vec::<u8>::new());
-    let mut header = Header::new_gnu();
-    header.set_metadata(&t!(fs::metadata(td.path()).await));
-    header.set_size(0);
-    for (a, b) in header.as_old_mut().name.iter_mut().zip(b"foo\\bar\x00") {
-        *a = *b;
-    }
-    header.set_cksum();
-    t!(ar.append(&header, &mut io::empty()).await);
-    let data = t!(ar.into_inner().await);
-    let ar = Archive::new(&data[..]);
-    let f = t!(t!(ar.entries()).next().await.unwrap());
-    assert_eq!(t!(f.header().path()).to_str(), Some("foo\\bar"));
-
-    let ar = Archive::new(&data[..]);
-    t!(ar.unpack(td.path()).await);
-    assert!(fs::metadata(td.path().join("foo\\bar")).await.is_ok());
+        let ar = Archive::new(&data[..]);
+        t!(ar.unpack(td.path()).await);
+        assert!(fs::metadata(td.path().join("foo\\bar")).await.is_ok());
+    });
 }
 
 #[cfg(unix)]
-#[async_std::test]
-async fn nul_bytes_in_path() {
-    use std::{ffi::OsStr, os::unix::prelude::*};
+#[test]
+fn nul_bytes_in_path() {
+    block_on(async {
+        use std::{ffi::OsStr, os::unix::prelude::*};
 
-    let nul_path = OsStr::from_bytes(b"foo\0");
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let mut ar = Builder::new(Vec::<u8>::new());
-    let err = ar.append_dir(nul_path, td.path()).await.unwrap_err();
-    assert!(err.to_string().contains("contains a nul byte"));
+        let nul_path = OsStr::from_bytes(b"foo\0");
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let mut ar = Builder::new(Vec::<u8>::new());
+        let err = ar.append_dir(nul_path, td.path()).await.unwrap_err();
+        assert!(err.to_string().contains("contains a nul byte"));
+    });
 }
 
-#[async_std::test]
-async fn links() {
-    let ar = Archive::new(Cursor::new(tar!("link.tar")));
-    let mut entries = t!(ar.entries());
-    let link = t!(entries.next().await.unwrap());
-    assert_eq!(
-        t!(link.header().link_name()).as_ref().map(|p| &**p),
-        Some(Path::new("file"))
-    );
-    let other = t!(entries.next().await.unwrap());
-    assert!(t!(other.header().link_name()).is_none());
+#[test]
+fn links() {
+    block_on(async {
+        let ar = Archive::new(Cursor::new(tar!("link.tar")));
+        let mut entries = t!(ar.entries());
+        let link = t!(entries.next().await.unwrap());
+        assert_eq!(
+            t!(link.header().link_name()).as_ref().map(|p| &**p),
+            Some(Path::new("file"))
+        );
+        let other = t!(entries.next().await.unwrap());
+        assert!(t!(other.header().link_name()).is_none());
+    });
 }
 
-#[async_std::test]
+#[test]
 #[cfg(unix)] // making symlinks on windows is hard
-async fn unpack_links() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let ar = Archive::new(Cursor::new(tar!("link.tar")));
-    t!(ar.unpack(td.path()).await);
+fn unpack_links() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let ar = Archive::new(Cursor::new(tar!("link.tar")));
+        t!(ar.unpack(td.path()).await);
 
-    let md = t!(fs::symlink_metadata(td.path().join("lnk")).await);
-    assert!(md.file_type().is_symlink());
-    assert_eq!(
-        &*t!(fs::read_link(td.path().join("lnk")).await),
-        Path::new("file")
-    );
-    t!(File::open(td.path().join("lnk")).await);
+        let md = t!(fs::symlink_metadata(td.path().join("lnk")).await);
+        assert!(md.file_type().is_symlink());
+        assert_eq!(
+            &*t!(fs::read_link(td.path().join("lnk")).await),
+            Path::new("file")
+        );
+        t!(File::open(td.path().join("lnk")).await);
+    });
 }
 
-#[async_std::test]
-async fn pax_simple() {
-    let ar = Archive::new(tar!("pax.tar"));
-    let mut entries = t!(ar.entries());
+#[test]
+fn pax_simple() {
+    block_on(async {
+        let ar = Archive::new(tar!("pax.tar"));
+        let mut entries = t!(ar.entries());
 
-    let mut first = t!(entries.next().await.unwrap());
-    let mut attributes = t!(first.pax_extensions().await).unwrap();
-    let first = t!(attributes.next().unwrap());
-    let second = t!(attributes.next().unwrap());
-    let third = t!(attributes.next().unwrap());
-    assert!(attributes.next().is_none());
+        let mut first = t!(entries.next().await.unwrap());
+        let mut attributes = t!(first.pax_extensions().await).unwrap();
+        let first = t!(attributes.next().unwrap());
+        let second = t!(attributes.next().unwrap());
+        let third = t!(attributes.next().unwrap());
+        assert!(attributes.next().is_none());
 
-    assert_eq!(first.key(), Ok("mtime"));
-    assert_eq!(first.value(), Ok("1453146164.953123768"));
-    assert_eq!(second.key(), Ok("atime"));
-    assert_eq!(second.value(), Ok("1453251915.24892486"));
-    assert_eq!(third.key(), Ok("ctime"));
-    assert_eq!(third.value(), Ok("1453146164.953123768"));
+        assert_eq!(first.key(), Ok("mtime"));
+        assert_eq!(first.value(), Ok("1453146164.953123768"));
+        assert_eq!(second.key(), Ok("atime"));
+        assert_eq!(second.value(), Ok("1453251915.24892486"));
+        assert_eq!(third.key(), Ok("ctime"));
+        assert_eq!(third.value(), Ok("1453146164.953123768"));
+    });
 }
 
-#[async_std::test]
-async fn pax_path() {
-    let ar = Archive::new(tar!("pax2.tar"));
-    let mut entries = t!(ar.entries());
+#[test]
+fn pax_path() {
+    block_on(async {
+        let ar = Archive::new(tar!("pax2.tar"));
+        let mut entries = t!(ar.entries());
 
-    let first = t!(entries.next().await.unwrap());
-    assert!(first.path().unwrap().ends_with("aaaaaaaaaaaaaaa"));
+        let first = t!(entries.next().await.unwrap());
+        assert!(first.path().unwrap().ends_with("aaaaaaaaaaaaaaa"));
+    });
 }
 
-#[async_std::test]
-async fn pax_precedence() {
-    let mut ar = Archive::new(tar!("pax-header-precedence.tar"));
-    let mut entries = t!(ar.entries());
+#[test]
+fn pax_precedence() {
+    block_on(async {
+        let ar = Archive::new(tar!("pax-header-precedence.tar"));
+        let mut entries = t!(ar.entries());
 
-    let first = t!(entries.next().await.unwrap());
-    assert!(first.path().unwrap().ends_with("normal.txt"));
+        let first = t!(entries.next().await.unwrap());
+        assert!(first.path().unwrap().ends_with("normal.txt"));
 
-    let second = t!(entries.next().await.unwrap());
-    assert!(second.path().unwrap().ends_with("blob.bin"));
+        let second = t!(entries.next().await.unwrap());
+        assert!(second.path().unwrap().ends_with("blob.bin"));
 
-    let third = t!(entries.next().await.unwrap());
-    assert!(third.path().unwrap().ends_with("marker.txt"));
+        let third = t!(entries.next().await.unwrap());
+        assert!(third.path().unwrap().ends_with("marker.txt"));
 
-    assert!(entries.next().await.is_none());
+        assert!(entries.next().await.is_none());
+    });
 }
 
-#[async_std::test]
-async fn long_name_trailing_nul() {
-    let mut b = Builder::new(Vec::<u8>::new());
+#[test]
+fn long_name_trailing_nul() {
+    block_on(async {
+        let mut b = Builder::new(Vec::<u8>::new());
 
-    let mut h = Header::new_gnu();
-    t!(h.set_path("././@LongLink"));
-    h.set_size(4);
-    h.set_entry_type(EntryType::new(b'L'));
-    h.set_cksum();
-    t!(b.append(&h, "foo\0".as_bytes()).await);
-    let mut h = Header::new_gnu();
+        let mut h = Header::new_gnu();
+        t!(h.set_path("././@LongLink"));
+        h.set_size(4);
+        h.set_entry_type(EntryType::new(b'L'));
+        h.set_cksum();
+        t!(b.append(&h, "foo\0".as_bytes()).await);
+        let mut h = Header::new_gnu();
 
-    t!(h.set_path("bar"));
-    h.set_size(6);
-    h.set_entry_type(EntryType::file());
-    h.set_cksum();
-    t!(b.append(&h, b"foobar" as &[u8]).await);
+        t!(h.set_path("bar"));
+        h.set_size(6);
+        h.set_entry_type(EntryType::file());
+        h.set_cksum();
+        t!(b.append(&h, b"foobar" as &[u8]).await);
 
-    let contents = t!(b.into_inner().await);
-    let a = Archive::new(&contents[..]);
+        let contents = t!(b.into_inner().await);
+        let a = Archive::new(&contents[..]);
 
-    let e = t!(t!(a.entries()).next().await.unwrap());
-    assert_eq!(&*e.path_bytes(), b"foo");
+        let e = t!(t!(a.entries()).next().await.unwrap());
+        assert_eq!(&*e.path_bytes(), b"foo");
+    });
 }
 
-#[async_std::test]
-async fn long_linkname_trailing_nul() {
-    let mut b = Builder::new(Vec::<u8>::new());
+#[test]
+fn long_linkname_trailing_nul() {
+    block_on(async {
+        let mut b = Builder::new(Vec::<u8>::new());
 
-    let mut h = Header::new_gnu();
-    t!(h.set_path("././@LongLink"));
-    h.set_size(4);
-    h.set_entry_type(EntryType::new(b'K'));
-    h.set_cksum();
-    t!(b.append(&h, "foo\0".as_bytes()).await);
-    let mut h = Header::new_gnu();
+        let mut h = Header::new_gnu();
+        t!(h.set_path("././@LongLink"));
+        h.set_size(4);
+        h.set_entry_type(EntryType::new(b'K'));
+        h.set_cksum();
+        t!(b.append(&h, "foo\0".as_bytes()).await);
+        let mut h = Header::new_gnu();
 
-    t!(h.set_path("bar"));
-    h.set_size(6);
-    h.set_entry_type(EntryType::file());
-    h.set_cksum();
-    t!(b.append(&h, b"foobar" as &[u8]).await);
+        t!(h.set_path("bar"));
+        h.set_size(6);
+        h.set_entry_type(EntryType::file());
+        h.set_cksum();
+        t!(b.append(&h, b"foobar" as &[u8]).await);
 
-    let contents = t!(b.into_inner().await);
-    let a = Archive::new(&contents[..]);
+        let contents = t!(b.into_inner().await);
+        let a = Archive::new(&contents[..]);
 
-    let e = t!(t!(a.entries()).next().await.unwrap());
-    assert_eq!(&*e.link_name_bytes().unwrap(), b"foo");
+        let e = t!(t!(a.entries()).next().await.unwrap());
+        assert_eq!(&*e.link_name_bytes().unwrap(), b"foo");
+    });
 }
 
-#[async_std::test]
-async fn encoded_long_name_has_trailing_nul() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let path = td.path().join("foo");
-    t!(t!(File::create(&path).await).write_all(b"test").await);
+#[test]
+fn encoded_long_name_has_trailing_nul() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let path = td.path().join("foo");
+        t!(t!(File::create(&path).await).write_all(b"test").await);
 
-    let mut b = Builder::new(Vec::<u8>::new());
-    let long = "abcd".repeat(200);
+        let mut b = Builder::new(Vec::<u8>::new());
+        let long = "abcd".repeat(200);
 
-    t!(b.append_file(&long, &mut t!(File::open(&path).await)).await);
+        t!(b.append_file(&long, &mut t!(File::open(&path).await)).await);
 
-    let contents = t!(b.into_inner().await);
-    let a = Archive::new(&contents[..]);
+        let contents = t!(b.into_inner().await);
+        let a = Archive::new(&contents[..]);
 
-    let mut e = t!(t!(a.entries_raw()).next().await.unwrap());
-    let mut name = Vec::new();
-    t!(e.read_to_end(&mut name).await);
-    assert_eq!(name[name.len() - 1], 0);
+        let mut e = t!(t!(a.entries_raw()).next().await.unwrap());
+        let mut name = Vec::new();
+        t!(e.read_to_end(&mut name).await);
+        assert_eq!(name[name.len() - 1], 0);
 
-    let header_name = &e.header().as_gnu().unwrap().name;
-    assert!(header_name.starts_with(b"././@LongLink\x00"));
+        let header_name = &e.header().as_gnu().unwrap().name;
+        assert!(header_name.starts_with(b"././@LongLink\x00"));
+    });
 }
 
-#[async_std::test]
-async fn reading_sparse() {
-    let rdr = Cursor::new(tar!("sparse.tar"));
-    let ar = Archive::new(rdr);
-    let mut entries = t!(ar.entries());
+#[test]
+fn reading_sparse() {
+    block_on(async {
+        let rdr = Cursor::new(tar!("sparse.tar"));
+        let ar = Archive::new(rdr);
+        let mut entries = t!(ar.entries());
 
-    let mut a = t!(entries.next().await.unwrap());
-    let mut s = String::new();
-    assert_eq!(&*a.header().path_bytes(), b"sparse_begin.txt");
-    t!(a.read_to_string(&mut s).await);
-    assert_eq!(&s[..5], "test\n");
-    assert!(s[5..].chars().all(|x| x == '\u{0}'));
+        let mut a = t!(entries.next().await.unwrap());
+        let mut s = String::new();
+        assert_eq!(&*a.header().path_bytes(), b"sparse_begin.txt");
+        t!(a.read_to_string(&mut s).await);
+        assert_eq!(&s[..5], "test\n");
+        assert!(s[5..].chars().all(|x| x == '\u{0}'));
 
-    let mut a = t!(entries.next().await.unwrap());
-    let mut s = String::new();
-    assert_eq!(&*a.header().path_bytes(), b"sparse_end.txt");
-    t!(a.read_to_string(&mut s).await);
-    assert!(s[..s.len() - 9].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[s.len() - 9..], "test_end\n");
+        let mut a = t!(entries.next().await.unwrap());
+        let mut s = String::new();
+        assert_eq!(&*a.header().path_bytes(), b"sparse_end.txt");
+        t!(a.read_to_string(&mut s).await);
+        assert!(s[..s.len() - 9].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[s.len() - 9..], "test_end\n");
 
-    let mut a = t!(entries.next().await.unwrap());
-    let mut s = String::new();
-    assert_eq!(&*a.header().path_bytes(), b"sparse_ext.txt");
-    t!(a.read_to_string(&mut s).await);
-    assert!(s[..0x1000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x1000..0x1000 + 5], "text\n");
-    assert!(s[0x1000 + 5..0x3000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x3000..0x3000 + 5], "text\n");
-    assert!(s[0x3000 + 5..0x5000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x5000..0x5000 + 5], "text\n");
-    assert!(s[0x5000 + 5..0x7000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x7000..0x7000 + 5], "text\n");
-    assert!(s[0x7000 + 5..0x9000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x9000..0x9000 + 5], "text\n");
-    assert!(s[0x9000 + 5..0xb000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0xb000..0xb000 + 5], "text\n");
+        let mut a = t!(entries.next().await.unwrap());
+        let mut s = String::new();
+        assert_eq!(&*a.header().path_bytes(), b"sparse_ext.txt");
+        t!(a.read_to_string(&mut s).await);
+        assert!(s[..0x1000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x1000..0x1000 + 5], "text\n");
+        assert!(s[0x1000 + 5..0x3000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x3000..0x3000 + 5], "text\n");
+        assert!(s[0x3000 + 5..0x5000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x5000..0x5000 + 5], "text\n");
+        assert!(s[0x5000 + 5..0x7000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x7000..0x7000 + 5], "text\n");
+        assert!(s[0x7000 + 5..0x9000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x9000..0x9000 + 5], "text\n");
+        assert!(s[0x9000 + 5..0xb000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0xb000..0xb000 + 5], "text\n");
 
-    let mut a = t!(entries.next().await.unwrap());
-    let mut s = String::new();
-    assert_eq!(&*a.header().path_bytes(), b"sparse.txt");
-    t!(a.read_to_string(&mut s).await);
-    assert!(s[..0x1000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x1000..0x1000 + 6], "hello\n");
-    assert!(s[0x1000 + 6..0x2fa0].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x2fa0..0x2fa0 + 6], "world\n");
-    assert!(s[0x2fa0 + 6..0x4000].chars().all(|x| x == '\u{0}'));
+        let mut a = t!(entries.next().await.unwrap());
+        let mut s = String::new();
+        assert_eq!(&*a.header().path_bytes(), b"sparse.txt");
+        t!(a.read_to_string(&mut s).await);
+        assert!(s[..0x1000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x1000..0x1000 + 6], "hello\n");
+        assert!(s[0x1000 + 6..0x2fa0].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x2fa0..0x2fa0 + 6], "world\n");
+        assert!(s[0x2fa0 + 6..0x4000].chars().all(|x| x == '\u{0}'));
 
-    assert!(entries.next().await.is_none());
+        assert!(entries.next().await.is_none());
+    });
 }
 
-#[async_std::test]
-async fn extract_sparse() {
-    let rdr = Cursor::new(tar!("sparse.tar"));
-    let ar = Archive::new(rdr);
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    t!(ar.unpack(td.path()).await);
+#[test]
+fn extract_sparse() {
+    block_on(async {
+        let rdr = Cursor::new(tar!("sparse.tar"));
+        let ar = Archive::new(rdr);
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        t!(ar.unpack(td.path()).await);
 
-    let mut s = String::new();
-    t!(t!(File::open(td.path().join("sparse_begin.txt")).await)
-        .read_to_string(&mut s)
-        .await);
-    assert_eq!(&s[..5], "test\n");
-    assert!(s[5..].chars().all(|x| x == '\u{0}'));
+        let mut s = String::new();
+        t!(t!(File::open(td.path().join("sparse_begin.txt")).await)
+            .read_to_string(&mut s)
+            .await);
+        assert_eq!(&s[..5], "test\n");
+        assert!(s[5..].chars().all(|x| x == '\u{0}'));
 
-    s.truncate(0);
-    t!(t!(File::open(td.path().join("sparse_end.txt")).await)
-        .read_to_string(&mut s)
-        .await);
-    assert!(s[..s.len() - 9].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[s.len() - 9..], "test_end\n");
+        s.truncate(0);
+        t!(t!(File::open(td.path().join("sparse_end.txt")).await)
+            .read_to_string(&mut s)
+            .await);
+        assert!(s[..s.len() - 9].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[s.len() - 9..], "test_end\n");
 
-    s.truncate(0);
-    t!(t!(File::open(td.path().join("sparse_ext.txt")).await)
-        .read_to_string(&mut s)
-        .await);
-    assert!(s[..0x1000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x1000..0x1000 + 5], "text\n");
-    assert!(s[0x1000 + 5..0x3000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x3000..0x3000 + 5], "text\n");
-    assert!(s[0x3000 + 5..0x5000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x5000..0x5000 + 5], "text\n");
-    assert!(s[0x5000 + 5..0x7000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x7000..0x7000 + 5], "text\n");
-    assert!(s[0x7000 + 5..0x9000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x9000..0x9000 + 5], "text\n");
-    assert!(s[0x9000 + 5..0xb000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0xb000..0xb000 + 5], "text\n");
+        s.truncate(0);
+        t!(t!(File::open(td.path().join("sparse_ext.txt")).await)
+            .read_to_string(&mut s)
+            .await);
+        assert!(s[..0x1000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x1000..0x1000 + 5], "text\n");
+        assert!(s[0x1000 + 5..0x3000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x3000..0x3000 + 5], "text\n");
+        assert!(s[0x3000 + 5..0x5000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x5000..0x5000 + 5], "text\n");
+        assert!(s[0x5000 + 5..0x7000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x7000..0x7000 + 5], "text\n");
+        assert!(s[0x7000 + 5..0x9000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x9000..0x9000 + 5], "text\n");
+        assert!(s[0x9000 + 5..0xb000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0xb000..0xb000 + 5], "text\n");
 
-    s.truncate(0);
-    t!(t!(File::open(td.path().join("sparse.txt")).await)
-        .read_to_string(&mut s)
-        .await);
-    assert!(s[..0x1000].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x1000..0x1000 + 6], "hello\n");
-    assert!(s[0x1000 + 6..0x2fa0].chars().all(|x| x == '\u{0}'));
-    assert_eq!(&s[0x2fa0..0x2fa0 + 6], "world\n");
-    assert!(s[0x2fa0 + 6..0x4000].chars().all(|x| x == '\u{0}'));
+        s.truncate(0);
+        t!(t!(File::open(td.path().join("sparse.txt")).await)
+            .read_to_string(&mut s)
+            .await);
+        assert!(s[..0x1000].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x1000..0x1000 + 6], "hello\n");
+        assert!(s[0x1000 + 6..0x2fa0].chars().all(|x| x == '\u{0}'));
+        assert_eq!(&s[0x2fa0..0x2fa0 + 6], "world\n");
+        assert!(s[0x2fa0 + 6..0x4000].chars().all(|x| x == '\u{0}'));
+    });
 }
 
-#[async_std::test]
-async fn path_separators() {
-    let mut ar = Builder::new(Vec::new());
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+#[test]
+fn path_separators() {
+    block_on(async {
+        let mut ar = Builder::new(Vec::new());
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let path = td.path().join("test");
-    t!(t!(File::create(&path).await).write_all(b"test").await);
+        let path = td.path().join("test");
+        t!(t!(File::create(&path).await).write_all(b"test").await);
 
-    let short_path: PathBuf = repeat("abcd").take(2).collect();
-    let long_path: PathBuf = repeat("abcd").take(50).collect();
+        let short_path: PathBuf = repeat("abcd").take(2).collect();
+        let long_path: PathBuf = repeat("abcd").take(50).collect();
 
-    // Make sure UStar headers normalize to Unix path separators
-    let mut header = Header::new_ustar();
+        // Make sure UStar headers normalize to Unix path separators
+        let mut header = Header::new_ustar();
 
-    t!(header.set_path(&short_path));
-    assert_eq!(t!(header.path()), short_path);
-    assert!(!header.path_bytes().contains(&b'\\'));
+        t!(header.set_path(&short_path));
+        assert_eq!(t!(header.path()), short_path);
+        assert!(!header.path_bytes().contains(&b'\\'));
 
-    t!(header.set_path(&long_path));
-    assert_eq!(t!(header.path()), long_path);
-    assert!(!header.path_bytes().contains(&b'\\'));
+        t!(header.set_path(&long_path));
+        assert_eq!(t!(header.path()), long_path);
+        assert!(!header.path_bytes().contains(&b'\\'));
 
-    // Make sure GNU headers normalize to Unix path separators,
-    // including the `@LongLink` fallback used by `append_file`.
-    t!(ar
-        .append_file(&short_path, &mut t!(File::open(&path).await))
-        .await);
-    t!(ar
-        .append_file(&long_path, &mut t!(File::open(&path).await))
-        .await);
+        // Make sure GNU headers normalize to Unix path separators,
+        // including the `@LongLink` fallback used by `append_file`.
+        t!(ar
+            .append_file(&short_path, &mut t!(File::open(&path).await))
+            .await);
+        t!(ar
+            .append_file(&long_path, &mut t!(File::open(&path).await))
+            .await);
 
-    let rd = Cursor::new(t!(ar.into_inner().await));
-    let ar = Archive::new(rd);
-    let mut entries = t!(ar.entries());
+        let rd = Cursor::new(t!(ar.into_inner().await));
+        let ar = Archive::new(rd);
+        let mut entries = t!(ar.entries());
 
-    let entry = t!(entries.next().await.unwrap());
-    assert_eq!(t!(entry.path()), short_path);
-    assert!(!entry.path_bytes().contains(&b'\\'));
+        let entry = t!(entries.next().await.unwrap());
+        assert_eq!(t!(entry.path()), short_path);
+        assert!(!entry.path_bytes().contains(&b'\\'));
 
-    let entry = t!(entries.next().await.unwrap());
-    assert_eq!(t!(entry.path()), long_path);
-    assert!(!entry.path_bytes().contains(&b'\\'));
+        let entry = t!(entries.next().await.unwrap());
+        assert_eq!(t!(entry.path()), long_path);
+        assert!(!entry.path_bytes().contains(&b'\\'));
 
-    assert!(entries.next().await.is_none());
+        assert!(entries.next().await.is_none());
+    });
 }
 
-#[async_std::test]
+#[test]
 #[cfg(unix)]
-async fn append_path_symlink() {
-    use std::{borrow::Cow, env, os::unix::fs::symlink};
+fn append_path_symlink() {
+    block_on(async {
+        use std::{borrow::Cow, env, os::unix::fs::symlink};
 
-    let mut ar = Builder::new(Vec::new());
-    ar.follow_symlinks(false);
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let mut ar = Builder::new(Vec::new());
+        ar.follow_symlinks(false);
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let long_linkname = "abcd".repeat(30);
-    let long_pathname = "dcba".repeat(30);
-    t!(env::set_current_dir(td.path()));
-    // "short" path name / short link name
-    t!(symlink("testdest", "test"));
-    t!(ar.append_path("test").await);
-    // short path name / long link name
-    t!(symlink(&long_linkname, "test2"));
-    t!(ar.append_path("test2").await);
-    // long path name / long link name
-    t!(symlink(&long_linkname, &long_pathname));
-    t!(ar.append_path(&long_pathname).await);
+        let long_linkname = "abcd".repeat(30);
+        let long_pathname = "dcba".repeat(30);
+        t!(env::set_current_dir(td.path()));
+        // "short" path name / short link name
+        t!(symlink("testdest", "test"));
+        t!(ar.append_path("test").await);
+        // short path name / long link name
+        t!(symlink(&long_linkname, "test2"));
+        t!(ar.append_path("test2").await);
+        // long path name / long link name
+        t!(symlink(&long_linkname, &long_pathname));
+        t!(ar.append_path(&long_pathname).await);
 
-    let rd = Cursor::new(t!(ar.into_inner().await));
-    let ar = Archive::new(rd);
-    let mut entries = t!(ar.entries());
+        let rd = Cursor::new(t!(ar.into_inner().await));
+        let ar = Archive::new(rd);
+        let mut entries = t!(ar.entries());
 
-    let entry = t!(entries.next().await.unwrap());
-    assert_eq!(t!(entry.path()), Path::new("test"));
-    assert_eq!(
-        t!(entry.link_name()),
-        Some(Cow::from(Path::new("testdest")))
-    );
-    assert_eq!(t!(entry.header().size()), 0);
+        let entry = t!(entries.next().await.unwrap());
+        assert_eq!(t!(entry.path()), Path::new("test"));
+        assert_eq!(
+            t!(entry.link_name()),
+            Some(Cow::from(Path::new("testdest")))
+        );
+        assert_eq!(t!(entry.header().size()), 0);
 
-    let entry = t!(entries.next().await.unwrap());
-    assert_eq!(t!(entry.path()), Path::new("test2"));
-    assert_eq!(
-        t!(entry.link_name()),
-        Some(Cow::from(Path::new(&long_linkname)))
-    );
-    assert_eq!(t!(entry.header().size()), 0);
+        let entry = t!(entries.next().await.unwrap());
+        assert_eq!(t!(entry.path()), Path::new("test2"));
+        assert_eq!(
+            t!(entry.link_name()),
+            Some(Cow::from(Path::new(&long_linkname)))
+        );
+        assert_eq!(t!(entry.header().size()), 0);
 
-    let entry = t!(entries.next().await.unwrap());
-    assert_eq!(t!(entry.path()), Path::new(&long_pathname));
-    assert_eq!(
-        t!(entry.link_name()),
-        Some(Cow::from(Path::new(&long_linkname)))
-    );
-    assert_eq!(t!(entry.header().size()), 0);
+        let entry = t!(entries.next().await.unwrap());
+        assert_eq!(t!(entry.path()), Path::new(&long_pathname));
+        assert_eq!(
+            t!(entry.link_name()),
+            Some(Cow::from(Path::new(&long_linkname)))
+        );
+        assert_eq!(t!(entry.header().size()), 0);
 
-    assert!(entries.next().await.is_none());
+        assert!(entries.next().await.is_none());
+    });
 }
 
-#[async_std::test]
-async fn name_with_slash_doesnt_fool_long_link_and_bsd_compat() {
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+#[test]
+fn name_with_slash_doesnt_fool_long_link_and_bsd_compat() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
 
-    let mut ar = Builder::new(Vec::new());
+        let mut ar = Builder::new(Vec::new());
 
-    let mut h = Header::new_gnu();
-    t!(h.set_path("././@LongLink"));
-    h.set_size(4);
-    h.set_entry_type(EntryType::new(b'L'));
-    h.set_cksum();
-    t!(ar.append(&h, "foo\0".as_bytes()).await);
+        let mut h = Header::new_gnu();
+        t!(h.set_path("././@LongLink"));
+        h.set_size(4);
+        h.set_entry_type(EntryType::new(b'L'));
+        h.set_cksum();
+        t!(ar.append(&h, "foo\0".as_bytes()).await);
 
-    let mut header = Header::new_gnu();
-    header.set_entry_type(EntryType::Regular);
-    t!(header.set_path("testdir/"));
-    header.set_size(0);
-    header.set_cksum();
-    t!(ar.append(&header, &mut io::empty()).await);
+        let mut header = Header::new_gnu();
+        header.set_entry_type(EntryType::Regular);
+        t!(header.set_path("testdir/"));
+        header.set_size(0);
+        header.set_cksum();
+        t!(ar.append(&header, &mut io::empty()).await);
 
-    // Extracting
-    let rdr = Cursor::new(t!(ar.into_inner().await));
-    let ar = Archive::new(rdr);
-    t!(ar.clone().unpack(td.path()).await);
+        // Extracting
+        let rdr = Cursor::new(t!(ar.into_inner().await));
+        let ar = Archive::new(rdr);
+        t!(ar.clone().unpack(td.path()).await);
 
-    // Iterating
-    let rdr = Cursor::new(ar.into_inner().map_err(|_| ()).unwrap().into_inner());
-    let ar = Archive::new(rdr);
-    assert!(t!(ar.entries()).all(|fr| fr.is_ok()).await);
+        // Iterating
+        let rdr = Cursor::new(ar.into_inner().map_err(|_| ()).unwrap().into_inner());
+        let ar = Archive::new(rdr);
+        assert!(t!(ar.entries()).all(|fr| fr.is_ok()).await);
 
-    assert!(td.path().join("foo").is_file());
+        assert!(td.path().join("foo").is_file());
+    });
 }
 
-#[async_std::test]
-async fn insert_local_file_different_name() {
-    let mut ar = Builder::new(Vec::new());
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let path = td.path().join("directory");
-    t!(fs::create_dir(&path).await);
-    ar.append_path_with_name(&path, "archive/dir")
-        .await
-        .unwrap();
-    let path = td.path().join("file");
-    t!(t!(File::create(&path).await).write_all(b"test").await);
-    ar.append_path_with_name(&path, "archive/dir/f")
-        .await
-        .unwrap();
+#[test]
+fn insert_local_file_different_name() {
+    block_on(async {
+        let mut ar = Builder::new(Vec::new());
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let path = td.path().join("directory");
+        t!(fs::create_dir(&path).await);
+        ar.append_path_with_name(&path, "archive/dir")
+            .await
+            .unwrap();
+        let path = td.path().join("file");
+        t!(t!(File::create(&path).await).write_all(b"test").await);
+        ar.append_path_with_name(&path, "archive/dir/f")
+            .await
+            .unwrap();
 
-    let rd = Cursor::new(t!(ar.into_inner().await));
-    let ar = Archive::new(rd);
-    let mut entries = t!(ar.entries());
-    let entry = t!(entries.next().await.unwrap());
-    assert_eq!(t!(entry.path()), Path::new("archive/dir"));
-    let entry = t!(entries.next().await.unwrap());
-    assert_eq!(t!(entry.path()), Path::new("archive/dir/f"));
-    assert!(entries.next().await.is_none());
+        let rd = Cursor::new(t!(ar.into_inner().await));
+        let ar = Archive::new(rd);
+        let mut entries = t!(ar.entries());
+        let entry = t!(entries.next().await.unwrap());
+        assert_eq!(t!(entry.path()), Path::new("archive/dir"));
+        let entry = t!(entries.next().await.unwrap());
+        assert_eq!(t!(entry.path()), Path::new("archive/dir/f"));
+        assert!(entries.next().await.is_none());
+    });
 }
 
-#[async_std::test]
+#[test]
 #[cfg(unix)]
-async fn tar_directory_containing_symlink_to_directory() {
-    use std::os::unix::fs::symlink;
+fn tar_directory_containing_symlink_to_directory() {
+    block_on(async {
+        use std::os::unix::fs::symlink;
 
-    let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
-    let dummy_src = t!(TempBuilder::new().prefix("dummy_src").tempdir());
-    let dummy_dst = td.path().join("dummy_dst");
-    let mut ar = Builder::new(Vec::new());
-    t!(symlink(dummy_src.path().display().to_string(), &dummy_dst));
+        let td = t!(TempBuilder::new().prefix("async-tar").tempdir());
+        let dummy_src = t!(TempBuilder::new().prefix("dummy_src").tempdir());
+        let dummy_dst = td.path().join("dummy_dst");
+        let mut ar = Builder::new(Vec::new());
+        t!(symlink(dummy_src.path().display().to_string(), &dummy_dst));
 
-    assert!(dummy_dst.read_link().is_ok());
-    assert!(dummy_dst.read_link().unwrap().is_dir());
-    ar.append_dir_all("symlinks", td.path()).await.unwrap();
-    ar.finish().await.unwrap();
+        assert!(dummy_dst.read_link().is_ok());
+        assert!(dummy_dst.read_link().unwrap().is_dir());
+        ar.append_dir_all("symlinks", td.path()).await.unwrap();
+        ar.finish().await.unwrap();
+    });
 }
 
-#[async_std::test]
-async fn long_path() {
-    let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
-    let rdr = Cursor::new(tar!("7z_long_path.tar"));
-    let ar = Archive::new(rdr);
-    ar.unpack(td.path()).await.unwrap();
+#[test]
+fn long_path() {
+    block_on(async {
+        let td = t!(TempBuilder::new().prefix("tar-rs").tempdir());
+        let rdr = Cursor::new(tar!("7z_long_path.tar"));
+        let ar = Archive::new(rdr);
+        ar.unpack(td.path()).await.unwrap();
+    });
 }

--- a/tests/entry.rs
+++ b/tests/entry.rs
@@ -1,10 +1,10 @@
 extern crate async_tar;
 extern crate tempfile;
 
-use async_std::{
-    fs::{create_dir, File},
-    prelude::*,
-};
+use smol::block_on;
+use smol::fs::{create_dir, File};
+use smol::io::AsyncReadExt;
+use smol::stream::StreamExt;
 
 use tempfile::Builder;
 
@@ -17,365 +17,389 @@ macro_rules! t {
     };
 }
 
-#[async_std::test]
-async fn absolute_symlink() {
-    let mut ar = async_tar::Builder::new(Vec::new());
+#[test]
+fn absolute_symlink() {
+    block_on(async {
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Symlink);
+        t!(header.set_path("foo"));
+        t!(header.set_link_name("/bar"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
-    t!(ar.unpack(td.path()).await);
+        let td = t!(Builder::new().prefix("tar").tempdir());
+        t!(ar.unpack(td.path()).await);
 
-    t!(td.path().join("foo").symlink_metadata());
+        t!(td.path().join("foo").symlink_metadata());
 
-    let ar = async_tar::Archive::new(&bytes[..]);
-    let mut entries = t!(ar.entries());
-    let entry = t!(entries.next().await.unwrap());
-    assert_eq!(&*entry.link_name_bytes().unwrap(), b"/bar");
+        let ar = async_tar::Archive::new(&bytes[..]);
+        let mut entries = t!(ar.entries());
+        let entry = t!(entries.next().await.unwrap());
+        assert_eq!(&*entry.link_name_bytes().unwrap(), b"/bar");
+    });
 }
 
-#[async_std::test]
-async fn absolute_hardlink() {
-    let td = t!(Builder::new().prefix("tar").tempdir());
-    let mut ar = async_tar::Builder::new(Vec::new());
+#[test]
+fn absolute_hardlink() {
+    block_on(async {
+        let td = t!(Builder::new().prefix("tar").tempdir());
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("foo"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Link);
-    t!(header.set_path("bar"));
-    // This absolute path under tempdir will be created at unpack time
-    t!(header.set_link_name(td.path().join("foo")));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Link);
+        t!(header.set_path("bar"));
+        // This absolute path under tempdir will be created at unpack time
+        t!(header.set_link_name(td.path().join("foo")));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    t!(ar.unpack(td.path()).await);
-    t!(td.path().join("foo").metadata());
-    t!(td.path().join("bar").metadata());
+        t!(ar.unpack(td.path()).await);
+        t!(td.path().join("foo").metadata());
+        t!(td.path().join("bar").metadata());
+    });
 }
 
-#[async_std::test]
-async fn relative_hardlink() {
-    let mut ar = async_tar::Builder::new(Vec::new());
+#[test]
+fn relative_hardlink() {
+    block_on(async {
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("foo"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Link);
-    t!(header.set_path("bar"));
-    t!(header.set_link_name("foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Link);
+        t!(header.set_path("bar"));
+        t!(header.set_link_name("foo"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
-    t!(ar.unpack(td.path()).await);
-    t!(td.path().join("foo").metadata());
-    t!(td.path().join("bar").metadata());
+        let td = t!(Builder::new().prefix("tar").tempdir());
+        t!(ar.unpack(td.path()).await);
+        t!(td.path().join("foo").metadata());
+        t!(td.path().join("bar").metadata());
+    });
 }
 
-#[async_std::test]
-async fn absolute_link_deref_error() {
-    let mut ar = async_tar::Builder::new(Vec::new());
+#[test]
+fn absolute_link_deref_error() {
+    block_on(async {
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("/"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Symlink);
+        t!(header.set_path("foo"));
+        t!(header.set_link_name("/"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("foo/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("foo/bar"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
-    assert!(ar.unpack(td.path()).await.is_err());
-    t!(td.path().join("foo").symlink_metadata());
-    assert!(File::open(td.path().join("foo").join("bar")).await.is_err());
+        let td = t!(Builder::new().prefix("tar").tempdir());
+        assert!(ar.unpack(td.path()).await.is_err());
+        t!(td.path().join("foo").symlink_metadata());
+        assert!(File::open(td.path().join("foo").join("bar")).await.is_err());
+    });
 }
 
-#[async_std::test]
-async fn relative_link_deref_error() {
-    let mut ar = async_tar::Builder::new(Vec::new());
+#[test]
+fn relative_link_deref_error() {
+    block_on(async {
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("../../../../"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Symlink);
+        t!(header.set_path("foo"));
+        t!(header.set_link_name("../../../../"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("foo/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("foo/bar"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
-    assert!(ar.unpack(td.path()).await.is_err());
-    t!(td.path().join("foo").symlink_metadata());
-    assert!(File::open(td.path().join("foo").join("bar")).await.is_err());
+        let td = t!(Builder::new().prefix("tar").tempdir());
+        assert!(ar.unpack(td.path()).await.is_err());
+        t!(td.path().join("foo").symlink_metadata());
+        assert!(File::open(td.path().join("foo").join("bar")).await.is_err());
+    });
 }
 
-#[async_std::test]
+#[test]
 #[cfg(unix)]
-async fn directory_maintains_permissions() {
-    use ::std::os::unix::fs::PermissionsExt;
+fn directory_maintains_permissions() {
+    block_on(async {
+        use ::std::os::unix::fs::PermissionsExt;
 
-    let mut ar = async_tar::Builder::new(Vec::new());
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Directory);
-    t!(header.set_path("foo"));
-    header.set_mode(0o777);
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Directory);
+        t!(header.set_path("foo"));
+        header.set_mode(0o777);
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
-    t!(ar.unpack(td.path()).await);
-    let f = t!(File::open(td.path().join("foo")).await);
-    let md = t!(f.metadata().await);
-    assert!(md.is_dir());
-    assert_eq!(md.permissions().mode(), 0o40777);
+        let td = t!(Builder::new().prefix("tar").tempdir());
+        t!(ar.unpack(td.path()).await);
+        let f = t!(File::open(td.path().join("foo")).await);
+        let md = t!(f.metadata().await);
+        assert!(md.is_dir());
+        assert_eq!(md.permissions().mode(), 0o40777);
+    });
 }
 
-#[async_std::test]
+#[test]
 #[cfg(not(windows))] // dangling symlinks have weird permissions
-async fn modify_link_just_created() {
-    let mut ar = async_tar::Builder::new(Vec::new());
+fn modify_link_just_created() {
+    block_on(async {
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Symlink);
+        t!(header.set_path("foo"));
+        t!(header.set_link_name("bar"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("bar/foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("bar/foo"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("foo/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("foo/bar"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
-    t!(ar.unpack(td.path()).await);
+        let td = t!(Builder::new().prefix("tar").tempdir());
+        t!(ar.unpack(td.path()).await);
 
-    t!(File::open(td.path().join("bar/foo")).await);
-    t!(File::open(td.path().join("bar/bar")).await);
-    t!(File::open(td.path().join("foo/foo")).await);
-    t!(File::open(td.path().join("foo/bar")).await);
+        t!(File::open(td.path().join("bar/foo")).await);
+        t!(File::open(td.path().join("bar/bar")).await);
+        t!(File::open(td.path().join("foo/foo")).await);
+        t!(File::open(td.path().join("foo/bar")).await);
+    });
 }
 
-#[async_std::test]
+#[test]
 #[cfg(not(windows))] // dangling symlinks have weird permissions
-async fn modify_outside_with_relative_symlink() {
-    let mut ar = async_tar::Builder::new(Vec::new());
+fn modify_outside_with_relative_symlink() {
+    block_on(async {
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
-    t!(header.set_path("symlink"));
-    t!(header.set_link_name(".."));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Symlink);
+        t!(header.set_path("symlink"));
+        t!(header.set_link_name(".."));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("symlink/foo/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("symlink/foo/bar"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
-    let tar_dir = td.path().join("tar");
-    create_dir(&tar_dir).await.unwrap();
-    assert!(ar.unpack(tar_dir).await.is_err());
-    assert!(!td.path().join("foo").exists());
+        let td = t!(Builder::new().prefix("tar").tempdir());
+        let tar_dir = td.path().join("tar");
+        create_dir(&tar_dir).await.unwrap();
+        assert!(ar.unpack(tar_dir).await.is_err());
+        assert!(!td.path().join("foo").exists());
+    });
 }
 
-#[async_std::test]
-async fn parent_paths_error() {
-    let mut ar = async_tar::Builder::new(Vec::new());
+#[test]
+fn parent_paths_error() {
+    block_on(async {
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
-    t!(header.set_path("foo"));
-    t!(header.set_link_name(".."));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Symlink);
+        t!(header.set_path("foo"));
+        t!(header.set_link_name(".."));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("foo/bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("foo/bar"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
-    assert!(ar.unpack(td.path()).await.is_err());
-    t!(td.path().join("foo").symlink_metadata());
-    assert!(File::open(td.path().join("foo").join("bar")).await.is_err());
+        let td = t!(Builder::new().prefix("tar").tempdir());
+        assert!(ar.unpack(td.path()).await.is_err());
+        t!(td.path().join("foo").symlink_metadata());
+        assert!(File::open(td.path().join("foo").join("bar")).await.is_err());
+    });
 }
 
-#[async_std::test]
+#[test]
 #[cfg(unix)]
-async fn good_parent_paths_ok() {
-    use std::path::PathBuf;
-    let mut ar = async_tar::Builder::new(Vec::new());
+fn good_parent_paths_ok() {
+    block_on(async {
+        use std::path::PathBuf;
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
-    t!(header.set_path(PathBuf::from("foo").join("bar")));
-    t!(header.set_link_name(PathBuf::from("..").join("bar")));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Symlink);
+        t!(header.set_path(PathBuf::from("foo").join("bar")));
+        t!(header.set_link_name(PathBuf::from("..").join("bar")));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("bar"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("bar"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
-    t!(ar.unpack(td.path()).await);
-    t!(td.path().join("foo").join("bar").read_link());
-    let dst = t!(td.path().join("foo").join("bar").canonicalize());
-    t!(File::open(dst).await);
+        let td = t!(Builder::new().prefix("tar").tempdir());
+        t!(ar.unpack(td.path()).await);
+        t!(td.path().join("foo").join("bar").read_link());
+        let dst = t!(td.path().join("foo").join("bar").canonicalize());
+        t!(File::open(dst).await);
+    });
 }
 
-#[async_std::test]
-async fn modify_hard_link_just_created() {
-    let mut ar = async_tar::Builder::new(Vec::new());
+#[test]
+fn modify_hard_link_just_created() {
+    block_on(async {
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Link);
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("../test"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Link);
+        t!(header.set_path("foo"));
+        t!(header.set_link_name("../test"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(1);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &b"x"[..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(1);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("foo"));
+        header.set_cksum();
+        t!(ar.append(&header, &b"x"[..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
+        let td = t!(Builder::new().prefix("tar").tempdir());
 
-    let test = td.path().join("test");
-    t!(File::create(&test).await);
+        let test = td.path().join("test");
+        t!(File::create(&test).await);
 
-    let dir = td.path().join("dir");
-    assert!(ar.unpack(&dir).await.is_err());
+        let dir = td.path().join("dir");
+        assert!(ar.unpack(&dir).await.is_err());
 
-    let mut contents = Vec::new();
-    t!(t!(File::open(&test).await).read_to_end(&mut contents).await);
-    assert_eq!(contents.len(), 0);
+        let mut contents = Vec::new();
+        t!(t!(File::open(&test).await).read_to_end(&mut contents).await);
+        assert_eq!(contents.len(), 0);
+    });
 }
 
-#[async_std::test]
-async fn modify_symlink_just_created() {
-    let mut ar = async_tar::Builder::new(Vec::new());
+#[test]
+fn modify_symlink_just_created() {
+    block_on(async {
+        let mut ar = async_tar::Builder::new(Vec::new());
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(0);
-    header.set_entry_type(async_tar::EntryType::Symlink);
-    t!(header.set_path("foo"));
-    t!(header.set_link_name("../test"));
-    header.set_cksum();
-    t!(ar.append(&header, &[][..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(0);
+        header.set_entry_type(async_tar::EntryType::Symlink);
+        t!(header.set_path("foo"));
+        t!(header.set_link_name("../test"));
+        header.set_cksum();
+        t!(ar.append(&header, &[][..]).await);
 
-    let mut header = async_tar::Header::new_gnu();
-    header.set_size(1);
-    header.set_entry_type(async_tar::EntryType::Regular);
-    t!(header.set_path("foo"));
-    header.set_cksum();
-    t!(ar.append(&header, &b"x"[..]).await);
+        let mut header = async_tar::Header::new_gnu();
+        header.set_size(1);
+        header.set_entry_type(async_tar::EntryType::Regular);
+        t!(header.set_path("foo"));
+        header.set_cksum();
+        t!(ar.append(&header, &b"x"[..]).await);
 
-    let bytes = t!(ar.into_inner().await);
-    let ar = async_tar::Archive::new(&bytes[..]);
+        let bytes = t!(ar.into_inner().await);
+        let ar = async_tar::Archive::new(&bytes[..]);
 
-    let td = t!(Builder::new().prefix("tar").tempdir());
+        let td = t!(Builder::new().prefix("tar").tempdir());
 
-    let test = td.path().join("test");
-    t!(File::create(&test).await);
+        let test = td.path().join("test");
+        t!(File::create(&test).await);
 
-    let dir = td.path().join("dir");
-    t!(ar.unpack(&dir).await);
+        let dir = td.path().join("dir");
+        t!(ar.unpack(&dir).await);
 
-    let mut contents = Vec::new();
-    t!(t!(File::open(&test).await).read_to_end(&mut contents).await);
-    assert_eq!(contents.len(), 0);
+        let mut contents = Vec::new();
+        t!(t!(File::open(&test).await).read_to_end(&mut contents).await);
+        assert_eq!(contents.len(), 0);
+    });
 }


### PR DESCRIPTION
Currently some tests are flaky
And this should probably be rebased on the tokio branch.

In the tests the only changes are
replacing the async_std macro that allows for async tests with
```rs
block_on(async {})
```
Should probably use https://docs.rs/smol-macros/latest/smol_macros/macro.test.html
instead.

And maybe https://docs.rs/async-compat/latest/async_compat/
could be of use.